### PR TITLE
feat: Project Management module — Project List, Detail, Gantt view, and API client improvements

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -44,6 +44,9 @@ import {
   TicketDetails,
   EditTicket,
 } from "./pages/support";
+import { ProjectList } from "./pages/projects/ProjectList";
+import { ProjectDetail } from "./pages/projects/ProjectDetail";
+import { Gantt } from "./pages/projects/Gantt";
 
 export const AppRoutes = () => {
   return (
@@ -136,6 +139,10 @@ export const AppRoutes = () => {
           path="/purchasing/orders/:id/edit"
           element={<PurchaseOrderListPage />}
         />
+        {/* Project routes */}
+        <Route path="/projects" element={<ProjectList />} />
+        <Route path="/projects/:id" element={<ProjectDetail />} />
+        <Route path="/projects/:id/gantt" element={<Gantt />} />
       </Route>
 
       {/* Default redirects */}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -25,7 +25,10 @@ function removeFromAll(key: string) {
 }
 
 function setOnStorage(key: string, value: string) {
-  const store = getStorageWithKey("erp_token") || getStorageWithKey("erp_refresh_token") || localStorage;
+  const store =
+    getStorageWithKey("erp_token") ||
+    getStorageWithKey("erp_refresh_token") ||
+    localStorage;
   store.setItem(key, value);
 }
 
@@ -54,6 +57,34 @@ const processQueue = (error: unknown, token: string | null = null) => {
   failedQueue = [];
 };
 
+const doRefresh = async (): Promise<string | null> => {
+  const refreshToken = localStorage.getItem("erp_refresh_token");
+  if (!refreshToken) return null;
+  try {
+    const response = await axios.post("/api/v1/auth/refresh", { refreshToken });
+    const data = response.data;
+    if (data.success && data.data) {
+      localStorage.setItem("erp_token", data.data.accessToken);
+      localStorage.setItem(
+        "erp_refresh_token",
+        data.data.refreshToken || refreshToken,
+      );
+      return data.data.accessToken;
+    }
+  } catch {
+    // refresh failed
+  }
+  return null;
+};
+
+// Proactively refresh token every 10 minutes to prevent expiry
+setInterval(
+  () => {
+    doRefresh();
+  },
+  10 * 60 * 1000,
+);
+
 apiClient.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
     const token = getTokenFromAny("erp_token") || getTokenFromAny("token");
@@ -74,7 +105,10 @@ apiClient.interceptors.response.use(
       _retry?: boolean;
     };
 
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    if (
+      (error.response?.status === 401 || error.response?.status === 403) &&
+      !originalRequest._retry
+    ) {
       if (isRefreshing) {
         return new Promise<string>((resolve, reject) => {
           failedQueue.push({ resolve, reject });
@@ -88,8 +122,8 @@ apiClient.interceptors.response.use(
       isRefreshing = true;
 
       const refreshToken = getTokenFromAny("erp_refresh_token");
-
       if (!refreshToken) {
+        processQueue(error, null);
         isRefreshing = false;
         removeFromAll("erp_token");
         removeFromAll("erp_refresh_token");

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   SettingOutlined,
   CustomerServiceOutlined,
   LogoutOutlined,
+  ProjectOutlined,
 } from "@ant-design/icons";
 import { AuthContext } from "../../../contexts/AuthContext";
 import styles from "./Sidebar.module.css";
@@ -41,6 +42,12 @@ export const Sidebar: React.FC<{ collapsed?: boolean }> = ({
       icon: <DashboardOutlined />,
       label: "Dashboard",
       onClick: () => navigate("/dashboard"),
+    },
+    {
+      key: "projects",
+      icon: <ProjectOutlined />,
+      label: "Projects",
+      onClick: () => navigate("/projects"),
     },
     {
       key: "inventory",
@@ -198,6 +205,7 @@ export const Sidebar: React.FC<{ collapsed?: boolean }> = ({
     if (path.startsWith("/admin/users")) return "users";
     if (path.startsWith("/admin/settings")) return "settings";
     if (path.startsWith("/admin/audit-logs")) return "audit-logs";
+    if (path.startsWith("/projects")) return "projects";
     if (path === "/dashboard") return "dashboard";
     return "";
   };

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -1,0 +1,135 @@
+import { useState, useEffect, useCallback } from 'react';
+import { projectService } from '../services/projectService';
+import type { Project, ProjectTask, TaskStage, GanttItem } from '../types/project';
+import type { ProjectListParams } from '../services/projectService';
+
+export const useProjects = (params?: ProjectListParams) => {
+  const [data, setData] = useState<Project[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await projectService.getAll(params);
+      setData(result.content);
+      setTotal(result.totalElements);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch projects');
+    } finally {
+      setLoading(false);
+    }
+  }, [params]);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  return { data, total, loading, error, refetch: fetch };
+};
+
+export const useProject = (id: number | null) => {
+  const [data, setData] = useState<Project | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await projectService.getById(id);
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch project');
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  return { data, loading, error, refetch: fetch };
+};
+
+export const useProjectTasks = (projectId: number | null) => {
+  const [data, setData] = useState<ProjectTask[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch = useCallback(async () => {
+    if (!projectId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await projectService.getTasks(projectId);
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch tasks');
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  return { data, loading, error, refetch: fetch };
+};
+
+export const useProjectStages = (projectId: number | null) => {
+  const [data, setData] = useState<TaskStage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch = useCallback(async () => {
+    if (!projectId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await projectService.getStages(projectId);
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch stages');
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  return { data, loading, error, refetch: fetch };
+};
+
+export const useGanttData = (projectId: number | null) => {
+  const [data, setData] = useState<GanttItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch = useCallback(async () => {
+    if (!projectId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await projectService.getGantt(projectId);
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch gantt data');
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  return { data, loading, error, refetch: fetch };
+};

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -1,9 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { projectService } from '../services/projectService';
-import type { Project, ProjectTask, TaskStage, GanttItem } from '../types/project';
-import type { ProjectListParams } from '../services/projectService';
+import type { Project, ProjectTask, TaskStage, GanttItem, ProjectState } from '../types/project';
 
-export const useProjects = (params?: ProjectListParams) => {
+export const useProjects = (page = 0, size = 20, state?: ProjectState, search?: string) => {
   const [data, setData] = useState<Project[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -13,7 +12,7 @@ export const useProjects = (params?: ProjectListParams) => {
     setLoading(true);
     setError(null);
     try {
-      const result = await projectService.getAll(params);
+      const result = await projectService.getAll({ page, size, state, search });
       setData(result.content);
       setTotal(result.totalElements);
     } catch (err) {
@@ -21,7 +20,7 @@ export const useProjects = (params?: ProjectListParams) => {
     } finally {
       setLoading(false);
     }
-  }, [params]);
+  }, [page, size, state, search]);
 
   useEffect(() => {
     fetch();

--- a/src/pages/projects/Gantt/Gantt.module.css
+++ b/src/pages/projects/Gantt/Gantt.module.css
@@ -7,24 +7,56 @@
   padding: 40px;
 }
 
-.timeline {
+.timelineWrapper {
+  display: flex;
   border: 1px solid #f0f0f0;
   border-radius: 8px;
   overflow: hidden;
 }
 
-.headerRow {
+.taskNameCol {
+  width: 260px;
+  flex-shrink: 0;
   display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 12px;
+  border-right: 1px solid #f0f0f0;
+  background: #fafafa;
+  font-weight: 600;
+  font-size: 13px;
+  overflow: hidden;
+}
+
+.timelineArea {
+  flex: 1;
+  min-width: 0;
+}
+
+.dateAxis {
+  position: relative;
+  height: 32px;
   background: #fafafa;
   border-bottom: 2px solid #f0f0f0;
-  font-weight: 600;
-  padding: 12px 16px;
+}
+
+.dateTick {
+  position: absolute;
+  top: 0;
+  font-size: 11px;
+  color: #888;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  padding-top: 8px;
+}
+
+.rows {
+  position: relative;
 }
 
 .taskRow {
   display: flex;
   align-items: center;
-  padding: 8px 16px;
   border-bottom: 1px solid #f0f0f0;
   transition: background 0.2s;
 }
@@ -37,37 +69,41 @@
   border-bottom: none;
 }
 
-.taskNameCol {
-  width: 300px;
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.taskRow .taskNameCol {
+  background: transparent;
+  border-right: 1px solid #f0f0f0;
+  font-weight: 400;
+  font-size: 13px;
 }
 
 .barCol {
   flex: 1;
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
+  padding: 6px 12px;
   position: relative;
+  min-width: 0;
 }
 
 .barTrack {
   flex: 1;
-  height: 28px;
+  height: 24px;
   background: #f5f5f5;
-  border-radius: 6px;
+  border-radius: 4px;
   position: relative;
   overflow: hidden;
+  min-width: 100px;
 }
 
 .taskBar {
-  height: 100%;
-  width: 60%;
-  border-radius: 6px;
+  position: absolute;
+  top: 2px;
+  height: 20px;
+  border-radius: 4px;
   opacity: 0.85;
   transition: opacity 0.2s;
+  min-width: 12px;
 }
 
 .taskBar:hover {
@@ -76,8 +112,14 @@
 
 .dateLabel {
   white-space: nowrap;
-  font-size: 12px;
-  min-width: 90px;
+  font-size: 11px;
+  min-width: 80px;
+}
+
+.hoursLabel {
+  white-space: nowrap;
+  font-size: 11px;
+  color: #999;
 }
 
 .legend {

--- a/src/pages/projects/Gantt/Gantt.module.css
+++ b/src/pages/projects/Gantt/Gantt.module.css
@@ -1,0 +1,89 @@
+.container {
+  padding: 24px;
+}
+
+.emptyState {
+  text-align: center;
+  padding: 40px;
+}
+
+.timeline {
+  border: 1px solid #f0f0f0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.headerRow {
+  display: flex;
+  background: #fafafa;
+  border-bottom: 2px solid #f0f0f0;
+  font-weight: 600;
+  padding: 12px 16px;
+}
+
+.taskRow {
+  display: flex;
+  align-items: center;
+  padding: 8px 16px;
+  border-bottom: 1px solid #f0f0f0;
+  transition: background 0.2s;
+}
+
+.taskRow:hover {
+  background: #fafafa;
+}
+
+.taskRow:last-child {
+  border-bottom: none;
+}
+
+.taskNameCol {
+  width: 300px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.barCol {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  position: relative;
+}
+
+.barTrack {
+  flex: 1;
+  height: 28px;
+  background: #f5f5f5;
+  border-radius: 6px;
+  position: relative;
+  overflow: hidden;
+}
+
+.taskBar {
+  height: 100%;
+  width: 60%;
+  border-radius: 6px;
+  opacity: 0.85;
+  transition: opacity 0.2s;
+}
+
+.taskBar:hover {
+  opacity: 1;
+}
+
+.dateLabel {
+  white-space: nowrap;
+  font-size: 12px;
+  min-width: 90px;
+}
+
+.legend {
+  margin-top: 16px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+}

--- a/src/pages/projects/Gantt/Gantt.tsx
+++ b/src/pages/projects/Gantt/Gantt.tsx
@@ -1,0 +1,102 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { Card, Button, Spin, Tag, Typography } from 'antd';
+import { ArrowLeftOutlined } from '@ant-design/icons';
+import { useGanttData, useProject } from '../../../hooks/useProjects';
+import styles from './Gantt.module.css';
+
+const { Text } = Typography;
+
+const STAGE_COLORS: Record<string, string> = {
+  'To Do': '#1890ff',
+  'In Progress': '#faad14',
+  'Done': '#52c41a',
+  'Review': '#722ed1',
+  'Testing': '#13c2c2',
+};
+
+const getStageColor = (stageName: string | null): string => {
+  if (!stageName) return '#d9d9d9';
+  return STAGE_COLORS[stageName] || '#d9d9d9';
+};
+
+export const Gantt: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const projectId = id ? Number(id) : null;
+
+  const { data: project } = useProject(projectId);
+  const { data: ganttItems, loading } = useGanttData(projectId);
+
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', padding: 80 }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  const sortedItems = [...ganttItems].sort((a, b) => {
+    if (!a.dueDate) return 1;
+    if (!b.dueDate) return -1;
+    return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
+  });
+
+  const stageNames = [...new Set(sortedItems.map((i) => i.stageName).filter(Boolean))] as string[];
+
+  return (
+    <div className={styles.container}>
+      <Button icon={<ArrowLeftOutlined />} onClick={() => navigate(`/projects/${projectId}`)} style={{ marginBottom: 16 }}>
+        Back to Project
+      </Button>
+
+      <Card title={`Gantt Chart${project ? ` - ${project.name}` : ''}`}>
+        {sortedItems.length === 0 ? (
+          <div className={styles.emptyState}>
+            <Text type="secondary">No tasks found for this project.</Text>
+          </div>
+        ) : (
+          <>
+            <div className={styles.timeline}>
+              <div className={styles.headerRow}>
+                <div className={styles.taskNameCol}>Task</div>
+                <div className={styles.barCol}>Timeline</div>
+              </div>
+              {sortedItems.map((item) => (
+                <div key={item.id} className={styles.taskRow}>
+                  <div className={styles.taskNameCol}>
+                    <Text strong>{item.name}</Text>
+                    {item.stageName && (
+                      <Tag color={getStageColor(item.stageName)} style={{ marginLeft: 8 }}>
+                        {item.stageName}
+                      </Tag>
+                    )}
+                  </div>
+                  <div className={styles.barCol}>
+                    <div className={styles.barTrack}>
+                      <div
+                        className={styles.taskBar}
+                        style={{ backgroundColor: getStageColor(item.stageName) }}
+                      />
+                    </div>
+                    {item.dueDate && (
+                      <Text type="secondary" className={styles.dateLabel}>{item.dueDate}</Text>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className={styles.legend}>
+              <Text type="secondary" style={{ marginRight: 12 }}>Legend:</Text>
+              {stageNames.map((name) => (
+                <Tag key={name} color={getStageColor(name)}>{name}</Tag>
+              ))}
+            </div>
+          </>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default Gantt;

--- a/src/pages/projects/Gantt/Gantt.tsx
+++ b/src/pages/projects/Gantt/Gantt.tsx
@@ -1,7 +1,10 @@
+import { useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Card, Button, Spin, Tag, Typography } from 'antd';
 import { ArrowLeftOutlined } from '@ant-design/icons';
+import dayjs from 'dayjs';
 import { useGanttData, useProject } from '../../../hooks/useProjects';
+import type { GanttItem } from '../../../types/project';
 import styles from './Gantt.module.css';
 
 const { Text } = Typography;
@@ -27,6 +30,31 @@ export const Gantt: React.FC = () => {
   const { data: project } = useProject(projectId);
   const { data: ganttItems, loading } = useGanttData(projectId);
 
+  const { sortedItems, totalDays, dateAxis, maxHours } = useMemo(() => {
+    if (!ganttItems || !project) return { sortedItems: [], totalDays: 0, dateAxis: [], maxHours: 1 };
+
+    const sorted = [...ganttItems].sort((a, b) => {
+      if (!a.dueDate) return 1;
+      if (!b.dueDate) return -1;
+      return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
+    });
+
+    const start = dayjs(project.dateStart);
+    const end = dayjs(project.dateEnd);
+    const days = end.diff(start, 'day') || 1;
+
+    const axis: string[] = [];
+    for (let i = 0; i <= days; i++) {
+      axis.push(start.add(i, 'day').format('MMM D'));
+    }
+
+    const maxEst = Math.max(...sorted.map((t) => t.estimatedHours || 0), 1);
+
+    return { sortedItems: sorted, totalDays: days, dateAxis: axis, maxHours: maxEst };
+  }, [ganttItems, project]);
+
+  const stageNames = [...new Set(sortedItems.map((i) => i.stageName).filter(Boolean))] as string[];
+
   if (loading) {
     return (
       <div style={{ display: 'flex', justifyContent: 'center', padding: 80 }}>
@@ -34,14 +62,6 @@ export const Gantt: React.FC = () => {
       </div>
     );
   }
-
-  const sortedItems = [...ganttItems].sort((a, b) => {
-    if (!a.dueDate) return 1;
-    if (!b.dueDate) return -1;
-    return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
-  });
-
-  const stageNames = [...new Set(sortedItems.map((i) => i.stageName).filter(Boolean))] as string[];
 
   return (
     <div className={styles.container}>
@@ -56,34 +76,57 @@ export const Gantt: React.FC = () => {
           </div>
         ) : (
           <>
-            <div className={styles.timeline}>
-              <div className={styles.headerRow}>
-                <div className={styles.taskNameCol}>Task</div>
-                <div className={styles.barCol}>Timeline</div>
-              </div>
-              {sortedItems.map((item) => (
-                <div key={item.id} className={styles.taskRow}>
-                  <div className={styles.taskNameCol}>
-                    <Text strong>{item.name}</Text>
-                    {item.stageName && (
-                      <Tag color={getStageColor(item.stageName)} style={{ marginLeft: 8 }}>
-                        {item.stageName}
-                      </Tag>
-                    )}
-                  </div>
-                  <div className={styles.barCol}>
-                    <div className={styles.barTrack}>
-                      <div
-                        className={styles.taskBar}
-                        style={{ backgroundColor: getStageColor(item.stageName) }}
-                      />
+            <div className={styles.timelineWrapper}>
+              <div className={styles.taskNameCol}>Task</div>
+              <div className={styles.timelineArea}>
+                <div className={styles.dateAxis}>
+                  {dateAxis.map((d, i) => (
+                    <div key={i} className={styles.dateTick} style={{ left: `${(i / totalDays) * 100}%` }}>
+                      {d}
                     </div>
-                    {item.dueDate && (
-                      <Text type="secondary" className={styles.dateLabel}>{item.dueDate}</Text>
-                    )}
-                  </div>
+                  ))}
                 </div>
-              ))}
+                <div className={styles.rows}>
+                  {sortedItems.map((item) => {
+                    const pos = item.dueDate && project?.dateStart
+                      ? dayjs(item.dueDate).diff(dayjs(project.dateStart), 'day')
+                      : 0;
+                    const leftPct = Math.max(0, (pos / totalDays) * 100);
+                    const widthPct = Math.max(8, ((item.estimatedHours || 1) / maxHours) * 60);
+
+                    return (
+                      <div key={item.id} className={styles.taskRow}>
+                        <div className={styles.taskNameCol}>
+                          <Text strong ellipsis>{item.name}</Text>
+                          {item.stageName && (
+                            <Tag color={getStageColor(item.stageName)} style={{ marginLeft: 4, fontSize: 11 }}>
+                              {item.stageName}
+                            </Tag>
+                          )}
+                        </div>
+                        <div className={styles.barCol}>
+                          <div className={styles.barTrack}>
+                            <div
+                              className={styles.taskBar}
+                              style={{
+                                left: `${Math.max(0, leftPct - widthPct)}%`,
+                                width: `${Math.min(widthPct, leftPct)}%`,
+                                backgroundColor: getStageColor(item.stageName),
+                              }}
+                            />
+                          </div>
+                          {item.dueDate && (
+                            <Text type="secondary" className={styles.dateLabel}>{item.dueDate}</Text>
+                          )}
+                          {item.estimatedHours && (
+                            <Text type="secondary" className={styles.hoursLabel}>{item.estimatedHours}h</Text>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
             </div>
 
             <div className={styles.legend}>

--- a/src/pages/projects/Gantt/index.ts
+++ b/src/pages/projects/Gantt/index.ts
@@ -1,0 +1,1 @@
+export { Gantt } from './Gantt';

--- a/src/pages/projects/ProjectDetail/ProjectDetail.module.css
+++ b/src/pages/projects/ProjectDetail/ProjectDetail.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 24px;
+}

--- a/src/pages/projects/ProjectDetail/ProjectDetail.tsx
+++ b/src/pages/projects/ProjectDetail/ProjectDetail.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Card, Descriptions, Tag, Button, Space, Spin, Table, Modal, Form, Input, DatePicker, message, Popconfirm } from 'antd';
-import { ArrowLeftOutlined, BarChartOutlined, PlusOutlined } from '@ant-design/icons';
-import { useProject, useProjectTasks } from '../../../hooks/useProjects';
+import dayjs from 'dayjs';
+import { Card, Descriptions, Tag, Button, Space, Spin, Table, Modal, Form, Input, DatePicker, message, Popconfirm, Select, Empty } from 'antd';
+import { ArrowLeftOutlined, BarChartOutlined, PlusOutlined, DeleteOutlined, EditOutlined } from '@ant-design/icons';
+import { useProject, useProjectTasks, useProjectStages } from '../../../hooks/useProjects';
 import { projectService } from '../../../services/projectService';
 import { PROJECT_STATE_LABELS, PROJECT_STATE_COLORS } from '../../../types/project';
-import type { ProjectState, CreateTaskRequest } from '../../../types/project';
+import type { ProjectState, CreateTaskRequest, UpdateTaskRequest, ProjectTask } from '../../../types/project';
 import styles from './ProjectDetail.module.css';
 
 const STATE_TRANSITIONS: Record<ProjectState, ProjectState[]> = {
@@ -24,8 +25,14 @@ export const ProjectDetail: React.FC = () => {
   const [creating, setCreating] = useState(false);
   const [form] = Form.useForm();
 
+  const [editingTask, setEditingTask] = useState<ProjectTask | null>(null);
+  const [editModalOpen, setEditModalOpen] = useState(false);
+  const [editForm] = Form.useForm();
+  const [updatingStage, setUpdatingStage] = useState<number | null>(null);
+
   const { data: project, loading, refetch: refetchProject } = useProject(projectId);
   const { data: tasks, loading: tasksLoading, refetch: refetchTasks } = useProjectTasks(projectId);
+  const { data: stages } = useProjectStages(projectId);
 
   const handleStateChange = async (newState: ProjectState) => {
     if (!projectId) return;
@@ -36,6 +43,61 @@ export const ProjectDetail: React.FC = () => {
     } catch (err) {
       message.error(err instanceof Error ? err.message : 'Failed to update state');
     }
+  };
+
+  const handleDeleteProject = async () => {
+    if (!projectId) return;
+    try {
+      await projectService.delete(projectId);
+      message.success('Project deleted successfully');
+      navigate('/projects');
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : 'Failed to delete project');
+    }
+  };
+
+  const handleEditTask = async (values: UpdateTaskRequest) => {
+    if (!editingTask) return;
+    try {
+      const payload: UpdateTaskRequest = {
+        ...values,
+        dueDate: values.dueDate ? String((values.dueDate as any).format?.('YYYY-MM-DD') ?? values.dueDate) : null,
+      };
+      await projectService.updateTask(editingTask.id, payload);
+      message.success('Task updated successfully');
+      setEditModalOpen(false);
+      setEditingTask(null);
+      editForm.resetFields();
+      refetchTasks();
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : 'Failed to update task');
+    }
+  };
+
+  const handleUpdateTaskStage = async (taskId: number, stageId: number) => {
+    setUpdatingStage(taskId);
+    try {
+      await projectService.updateTask(taskId, { stageId });
+      message.success('Task stage updated');
+      refetchTasks();
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : 'Failed to update task stage');
+    } finally {
+      setUpdatingStage(null);
+    }
+  };
+
+  const openEditModal = (task: ProjectTask) => {
+    setEditingTask(task);
+    editForm.setFieldsValue({
+      name: task.name,
+      description: task.description,
+      dueDate: task.dueDate ? dayjs(task.dueDate) : null,
+      estimatedHours: task.estimatedHours,
+      actualHours: task.actualHours,
+      stageId: task.stageId,
+    });
+    setEditModalOpen(true);
   };
 
   const handleCreateTask = async (values: CreateTaskRequest) => {
@@ -76,9 +138,23 @@ export const ProjectDetail: React.FC = () => {
     { title: 'Name', dataIndex: 'name', key: 'name' },
     {
       title: 'Stage',
-      dataIndex: 'stageName',
-      key: 'stageName',
-      render: (name: string | null) => name || '-',
+      key: 'stage',
+      width: 160,
+      render: (_: unknown, record: ProjectTask) => {
+        const stageOptions = (stages || []).map((s) => ({ value: s.id, label: s.name }));
+        const currentStageId = record.stageId;
+        return (
+          <Select
+            value={currentStageId}
+            options={stageOptions}
+            onChange={(val) => handleUpdateTaskStage(record.id, val)}
+            loading={updatingStage === record.id}
+            size="small"
+            style={{ width: 130 }}
+            placeholder="Set stage"
+          />
+        );
+      },
     },
     { title: 'Due Date', dataIndex: 'dueDate', key: 'dueDate', render: (d: string | null) => d || '-' },
     {
@@ -93,13 +169,26 @@ export const ProjectDetail: React.FC = () => {
       key: 'actualHours',
       render: (h: number | null) => h ?? '-',
     },
+    {
+      title: 'Actions',
+      key: 'actions',
+      width: 80,
+      render: (_: unknown, record: ProjectTask) => (
+        <Button type="link" icon={<EditOutlined />} onClick={() => openEditModal(record)} />
+      ),
+    },
   ];
 
   return (
     <div className={styles.container}>
-      <Button icon={<ArrowLeftOutlined />} onClick={() => navigate('/projects')} style={{ marginBottom: 16 }}>
-        Back to Projects
-      </Button>
+      <Space style={{ marginBottom: 16 }}>
+        <Button icon={<ArrowLeftOutlined />} onClick={() => navigate('/projects')}>
+          Back to Projects
+        </Button>
+        <Popconfirm title="Delete this project?" onConfirm={handleDeleteProject}>
+          <Button danger icon={<DeleteOutlined />}>Delete Project</Button>
+        </Popconfirm>
+      </Space>
 
       <Card
         title={project.name}
@@ -138,18 +227,26 @@ export const ProjectDetail: React.FC = () => {
         title="Tasks"
         style={{ marginTop: 16 }}
         extra={
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setTaskModalOpen(true)}>
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => {
+            const defaultStage = stages?.find((s) => s.isDefault);
+            if (defaultStage) form.setFieldValue('stageId', defaultStage.id);
+            setTaskModalOpen(true);
+          }}>
             Add Task
           </Button>
         }
       >
-        <Table
-          dataSource={tasks}
-          columns={taskColumns}
-          rowKey="id"
-          loading={tasksLoading}
-          pagination={false}
-        />
+        {tasks.length === 0 && !tasksLoading ? (
+          <Empty description="No tasks yet" />
+        ) : (
+          <Table
+            dataSource={tasks}
+            columns={taskColumns}
+            rowKey="id"
+            loading={tasksLoading}
+            pagination={false}
+          />
+        )}
       </Card>
 
       <Modal
@@ -171,9 +268,53 @@ export const ProjectDetail: React.FC = () => {
           <Form.Item name="estimatedHours" label="Estimated Hours">
             <Input type="number" min={0} />
           </Form.Item>
+          <Form.Item name="stageId" label="Stage">
+            <Select
+              options={(stages || []).map((s) => ({ value: s.id, label: s.name }))}
+              placeholder="Select stage"
+              defaultValue={stages?.find((s) => s.isDefault)?.id}
+            />
+          </Form.Item>
           <Form.Item>
             <Button type="primary" htmlType="submit" loading={creating} block>
               Create Task
+            </Button>
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <Modal
+        title="Edit Task"
+        open={editModalOpen}
+        onCancel={() => { setEditModalOpen(false); setEditingTask(null); editForm.resetFields(); }}
+        footer={null}
+      >
+        <Form form={editForm} layout="vertical" onFinish={handleEditTask}>
+          <Form.Item name="name" label="Task Name" rules={[{ required: true, message: 'Name is required' }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item name="description" label="Description">
+            <Input.TextArea rows={3} />
+          </Form.Item>
+          <Form.Item name="dueDate" label="Due Date">
+            <DatePicker style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item name="estimatedHours" label="Estimated Hours">
+            <Input type="number" min={0} />
+          </Form.Item>
+          <Form.Item name="actualHours" label="Actual Hours">
+            <Input type="number" min={0} />
+          </Form.Item>
+          <Form.Item name="stageId" label="Stage">
+            <Select
+              options={(stages || []).map((s) => ({ value: s.id, label: s.name }))}
+              placeholder="Select stage"
+              allowClear
+            />
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit" block>
+              Update Task
             </Button>
           </Form.Item>
         </Form>

--- a/src/pages/projects/ProjectDetail/ProjectDetail.tsx
+++ b/src/pages/projects/ProjectDetail/ProjectDetail.tsx
@@ -1,0 +1,185 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Card, Descriptions, Tag, Button, Space, Spin, Table, Modal, Form, Input, DatePicker, message, Popconfirm } from 'antd';
+import { ArrowLeftOutlined, BarChartOutlined, PlusOutlined } from '@ant-design/icons';
+import { useProject, useProjectTasks } from '../../../hooks/useProjects';
+import { projectService } from '../../../services/projectService';
+import { PROJECT_STATE_LABELS, PROJECT_STATE_COLORS } from '../../../types/project';
+import type { ProjectState, CreateTaskRequest } from '../../../types/project';
+import styles from './ProjectDetail.module.css';
+
+const STATE_TRANSITIONS: Record<ProjectState, ProjectState[]> = {
+  PLANNING: ['IN_PROGRESS'],
+  IN_PROGRESS: ['ON_HOLD', 'COMPLETED'],
+  ON_HOLD: ['IN_PROGRESS', 'CANCELLED'],
+  COMPLETED: [],
+  CANCELLED: [],
+};
+
+export const ProjectDetail: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const projectId = id ? Number(id) : null;
+  const [taskModalOpen, setTaskModalOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [form] = Form.useForm();
+
+  const { data: project, loading, refetch: refetchProject } = useProject(projectId);
+  const { data: tasks, loading: tasksLoading, refetch: refetchTasks } = useProjectTasks(projectId);
+
+  const handleStateChange = async (newState: ProjectState) => {
+    if (!projectId) return;
+    try {
+      await projectService.updateState(projectId, newState);
+      message.success(`Project state updated to ${PROJECT_STATE_LABELS[newState]}`);
+      refetchProject();
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : 'Failed to update state');
+    }
+  };
+
+  const handleCreateTask = async (values: CreateTaskRequest) => {
+    if (!projectId) return;
+    setCreating(true);
+    try {
+      const payload: CreateTaskRequest = {
+        ...values,
+        dueDate: values.dueDate ? String((values.dueDate as any).format?.('YYYY-MM-DD') ?? values.dueDate) : null,
+      };
+      await projectService.createTask(projectId, payload);
+      message.success('Task created successfully');
+      setTaskModalOpen(false);
+      form.resetFields();
+      refetchTasks();
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : 'Failed to create task');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', padding: 80 }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (!project) {
+    return <div style={{ padding: 24 }}>Project not found</div>;
+  }
+
+  const availableTransitions = STATE_TRANSITIONS[project.state] || [];
+
+  const taskColumns = [
+    { title: 'Name', dataIndex: 'name', key: 'name' },
+    {
+      title: 'Stage',
+      dataIndex: 'stageName',
+      key: 'stageName',
+      render: (name: string | null) => name || '-',
+    },
+    { title: 'Due Date', dataIndex: 'dueDate', key: 'dueDate', render: (d: string | null) => d || '-' },
+    {
+      title: 'Est. Hours',
+      dataIndex: 'estimatedHours',
+      key: 'estimatedHours',
+      render: (h: number | null) => h ?? '-',
+    },
+    {
+      title: 'Actual Hours',
+      dataIndex: 'actualHours',
+      key: 'actualHours',
+      render: (h: number | null) => h ?? '-',
+    },
+  ];
+
+  return (
+    <div className={styles.container}>
+      <Button icon={<ArrowLeftOutlined />} onClick={() => navigate('/projects')} style={{ marginBottom: 16 }}>
+        Back to Projects
+      </Button>
+
+      <Card
+        title={project.name}
+        extra={
+          <Space>
+            {availableTransitions.map((state) => (
+              <Popconfirm
+                key={state}
+                title={`Move to ${PROJECT_STATE_LABELS[state]}?`}
+                onConfirm={() => handleStateChange(state)}
+              >
+                <Button size="small">Move to {PROJECT_STATE_LABELS[state]}</Button>
+              </Popconfirm>
+            ))}
+            <Button
+              icon={<BarChartOutlined />}
+              onClick={() => navigate(`/projects/${projectId}/gantt`)}
+            >
+              Gantt View
+            </Button>
+          </Space>
+        }
+      >
+        <Descriptions column={2}>
+          <Descriptions.Item label="State">
+            <Tag color={PROJECT_STATE_COLORS[project.state]}>{PROJECT_STATE_LABELS[project.state]}</Tag>
+          </Descriptions.Item>
+          <Descriptions.Item label="Budget">{project.budget ? `$${project.budget.toLocaleString()}` : '-'}</Descriptions.Item>
+          <Descriptions.Item label="Start Date">{project.dateStart || '-'}</Descriptions.Item>
+          <Descriptions.Item label="End Date">{project.dateEnd || '-'}</Descriptions.Item>
+          <Descriptions.Item label="Created">{project.createdAt ? new Date(project.createdAt).toLocaleDateString() : '-'}</Descriptions.Item>
+        </Descriptions>
+      </Card>
+
+      <Card
+        title="Tasks"
+        style={{ marginTop: 16 }}
+        extra={
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setTaskModalOpen(true)}>
+            Add Task
+          </Button>
+        }
+      >
+        <Table
+          dataSource={tasks}
+          columns={taskColumns}
+          rowKey="id"
+          loading={tasksLoading}
+          pagination={false}
+        />
+      </Card>
+
+      <Modal
+        title="New Task"
+        open={taskModalOpen}
+        onCancel={() => { setTaskModalOpen(false); form.resetFields(); }}
+        footer={null}
+      >
+        <Form form={form} layout="vertical" onFinish={handleCreateTask}>
+          <Form.Item name="name" label="Task Name" rules={[{ required: true, message: 'Name is required' }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item name="description" label="Description">
+            <Input.TextArea rows={3} />
+          </Form.Item>
+          <Form.Item name="dueDate" label="Due Date">
+            <DatePicker style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item name="estimatedHours" label="Estimated Hours">
+            <Input type="number" min={0} />
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit" loading={creating} block>
+              Create Task
+            </Button>
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+};
+
+export default ProjectDetail;

--- a/src/pages/projects/ProjectDetail/index.ts
+++ b/src/pages/projects/ProjectDetail/index.ts
@@ -1,0 +1,1 @@
+export { ProjectDetail } from './ProjectDetail';

--- a/src/pages/projects/ProjectList/ProjectList.module.css
+++ b/src/pages/projects/ProjectList/ProjectList.module.css
@@ -1,0 +1,12 @@
+.container {
+  padding: 24px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+  gap: 12px;
+}

--- a/src/pages/projects/ProjectList/ProjectList.tsx
+++ b/src/pages/projects/ProjectList/ProjectList.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react';
+import { Card, Table, Button, Input, Select, Space, Modal, Form, message, Tag, DatePicker } from 'antd';
+import { PlusOutlined, SearchOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
+import { useProjects } from '../../../hooks/useProjects';
+import { projectService } from '../../../services/projectService';
+import { PROJECT_STATE_LABELS, PROJECT_STATE_COLORS } from '../../../types/project';
+import type { ProjectState, CreateProjectRequest } from '../../../types/project';
+import styles from './ProjectList.module.css';
+
+export const ProjectList: React.FC = () => {
+  const [page, setPage] = useState(0);
+  const [size] = useState(20);
+  const [search, setSearch] = useState('');
+  const [stateFilter, setStateFilter] = useState<ProjectState | undefined>();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [form] = Form.useForm();
+  const navigate = useNavigate();
+
+  const { data, total, loading, refetch } = useProjects({ page, size, state: stateFilter, search: search || undefined });
+
+  const handleCreate = async (values: CreateProjectRequest) => {
+    setCreating(true);
+    try {
+      const payload: CreateProjectRequest = {
+        ...values,
+        dateStart: values.dateStart ? String((values.dateStart as any).format?.('YYYY-MM-DD') ?? values.dateStart) : null,
+        dateEnd: values.dateEnd ? String((values.dateEnd as any).format?.('YYYY-MM-DD') ?? values.dateEnd) : null,
+      };
+      await projectService.create(payload);
+      message.success('Project created successfully');
+      setModalOpen(false);
+      form.resetFields();
+      refetch();
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : 'Failed to create project');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const columns = [
+    {
+      title: 'Name',
+      dataIndex: 'name',
+      key: 'name',
+      render: (name: string, record: { id: number }) => (
+        <a onClick={() => navigate(`/projects/${record.id}`)}>{name}</a>
+      ),
+    },
+    {
+      title: 'State',
+      dataIndex: 'state',
+      key: 'state',
+      width: 120,
+      render: (state: ProjectState) => (
+        <Tag color={PROJECT_STATE_COLORS[state]}>{PROJECT_STATE_LABELS[state]}</Tag>
+      ),
+    },
+    {
+      title: 'Start Date',
+      dataIndex: 'dateStart',
+      key: 'dateStart',
+      width: 120,
+    },
+    {
+      title: 'End Date',
+      dataIndex: 'dateEnd',
+      key: 'dateEnd',
+      width: 120,
+    },
+    {
+      title: 'Budget',
+      dataIndex: 'budget',
+      key: 'budget',
+      width: 120,
+      render: (budget: number | null) => (budget ? `$${budget.toLocaleString()}` : '-'),
+    },
+  ];
+
+  return (
+    <div className={styles.container}>
+      <Card>
+        <div className={styles.header}>
+          <Space>
+            <Input
+              placeholder="Search projects..."
+              prefix={<SearchOutlined />}
+              value={search}
+              onChange={(e) => { setSearch(e.target.value); setPage(0); }}
+              style={{ width: 250 }}
+              allowClear
+            />
+            <Select
+              placeholder="Filter by state"
+              value={stateFilter}
+              onChange={(val) => { setStateFilter(val); setPage(0); }}
+              allowClear
+              style={{ width: 150 }}
+              options={Object.entries(PROJECT_STATE_LABELS).map(([key, label]) => ({
+                value: key,
+                label,
+              }))}
+            />
+          </Space>
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalOpen(true)}>
+            New Project
+          </Button>
+        </div>
+
+        <Table
+          dataSource={data}
+          columns={columns}
+          rowKey="id"
+          loading={loading}
+          pagination={{
+            current: page + 1,
+            pageSize: size,
+            total,
+            onChange: (p) => setPage(p - 1),
+            showSizeChanger: false,
+          }}
+          onRow={(record) => ({
+            onClick: () => navigate(`/projects/${record.id}`),
+            style: { cursor: 'pointer' },
+          })}
+        />
+      </Card>
+
+      <Modal
+        title="New Project"
+        open={modalOpen}
+        onCancel={() => { setModalOpen(false); form.resetFields(); }}
+        footer={null}
+      >
+        <Form form={form} layout="vertical" onFinish={handleCreate}>
+          <Form.Item name="name" label="Project Name" rules={[{ required: true, message: 'Name is required' }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item name="dateStart" label="Start Date">
+            <DatePicker style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item name="dateEnd" label="End Date">
+            <DatePicker style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item name="budget" label="Budget">
+            <Input type="number" prefix="$" min={0} />
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit" loading={creating} block>
+              Create Project
+            </Button>
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+};
+
+export default ProjectList;

--- a/src/pages/projects/ProjectList/ProjectList.tsx
+++ b/src/pages/projects/ProjectList/ProjectList.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Card, Table, Button, Input, Select, Space, Modal, Form, message, Tag, DatePicker } from 'antd';
+import { Card, Table, Button, Input, Select, Space, Modal, Form, message, Tag, DatePicker, Empty } from 'antd';
 import { PlusOutlined, SearchOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 import { useProjects } from '../../../hooks/useProjects';
@@ -18,7 +18,7 @@ export const ProjectList: React.FC = () => {
   const [form] = Form.useForm();
   const navigate = useNavigate();
 
-  const { data, total, loading, refetch } = useProjects({ page, size, state: stateFilter, search: search || undefined });
+  const { data, total, loading, refetch } = useProjects(page, size, stateFilter, search || undefined);
 
   const handleCreate = async (values: CreateProjectRequest) => {
     setCreating(true);
@@ -109,6 +109,9 @@ export const ProjectList: React.FC = () => {
           </Button>
         </div>
 
+        {data.length === 0 && !loading ? (
+          <Empty description="No projects found" />
+        ) : (
         <Table
           dataSource={data}
           columns={columns}
@@ -126,6 +129,7 @@ export const ProjectList: React.FC = () => {
             style: { cursor: 'pointer' },
           })}
         />
+        )}
       </Card>
 
       <Modal

--- a/src/pages/projects/ProjectList/index.ts
+++ b/src/pages/projects/ProjectList/index.ts
@@ -1,0 +1,1 @@
+export { ProjectList } from './ProjectList';

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -1,0 +1,110 @@
+import { apiClient as api, handleApiError } from "../api/client";
+import type { Project, CreateProjectRequest, ProjectTask, CreateTaskRequest, UpdateTaskRequest, TaskStage, GanttItem, ProjectState } from "../types/project";
+
+export interface ProjectListParams {
+  page?: number;
+  size?: number;
+  state?: ProjectState;
+  search?: string;
+}
+
+interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}
+
+export const projectService = {
+  getAll: async (params?: ProjectListParams): Promise<PageResponse<Project>> => {
+    try {
+      const response = await api.get('/v1/projects', { params });
+      return response.data.data;
+    } catch (error) {
+      throw new Error(handleApiError(error));
+    }
+  },
+
+  getById: async (id: number): Promise<Project> => {
+    try {
+      const response = await api.get(`/v1/projects/${id}`);
+      return response.data.data;
+    } catch (error) {
+      throw new Error(handleApiError(error));
+    }
+  },
+
+  create: async (data: CreateProjectRequest): Promise<Project> => {
+    try {
+      const response = await api.post('/v1/projects', data);
+      return response.data.data;
+    } catch (error) {
+      throw new Error(handleApiError(error));
+    }
+  },
+
+  updateState: async (id: number, state: ProjectState): Promise<Project> => {
+    try {
+      const response = await api.patch(`/v1/projects/${id}/state`, state);
+      return response.data.data;
+    } catch (error) {
+      throw new Error(handleApiError(error));
+    }
+  },
+
+  delete: async (id: number): Promise<void> => {
+    try {
+      await api.delete(`/v1/projects/${id}`);
+    } catch (error) {
+      throw new Error(handleApiError(error));
+    }
+  },
+
+  getStages: async (projectId: number): Promise<TaskStage[]> => {
+    try {
+      const response = await api.get(`/v1/projects/${projectId}/stages`);
+      return response.data.data;
+    } catch (error) {
+      throw new Error(handleApiError(error));
+    }
+  },
+
+  getTasks: async (projectId: number): Promise<ProjectTask[]> => {
+    try {
+      const response = await api.get(`/v1/projects/${projectId}/tasks`);
+      return response.data.data;
+    } catch (error) {
+      throw new Error(handleApiError(error));
+    }
+  },
+
+  createTask: async (projectId: number, data: CreateTaskRequest): Promise<ProjectTask> => {
+    try {
+      const response = await api.post(`/v1/projects/${projectId}/tasks`, data);
+      return response.data.data;
+    } catch (error) {
+      throw new Error(handleApiError(error));
+    }
+  },
+
+  updateTask: async (taskId: number, data: UpdateTaskRequest): Promise<ProjectTask> => {
+    try {
+      const response = await api.put(`/v1/tasks/${taskId}`, data);
+      return response.data.data;
+    } catch (error) {
+      throw new Error(handleApiError(error));
+    }
+  },
+
+  getGantt: async (projectId: number): Promise<GanttItem[]> => {
+    try {
+      const response = await api.get(`/v1/projects/${projectId}/gantt`);
+      return response.data.data;
+    } catch (error) {
+      throw new Error(handleApiError(error));
+    }
+  },
+};
+
+export default projectService;

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,90 @@
+export type ProjectState = 'PLANNING' | 'IN_PROGRESS' | 'ON_HOLD' | 'COMPLETED' | 'CANCELLED';
+
+export interface Project {
+  id: number;
+  name: string;
+  customerId: number | null;
+  dateStart: string | null;
+  dateEnd: string | null;
+  budget: number | null;
+  state: ProjectState;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateProjectRequest {
+  name: string;
+  customerId?: number | null;
+  dateStart?: string | null;
+  dateEnd?: string | null;
+  budget?: number | null;
+}
+
+export interface ProjectTask {
+  id: number;
+  projectId: number;
+  name: string;
+  description: string | null;
+  assignedTo: number | null;
+  stageId: number | null;
+  stageName: string | null;
+  dueDate: string | null;
+  estimatedHours: number | null;
+  actualHours: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateTaskRequest {
+  name: string;
+  description?: string | null;
+  assignedTo?: number | null;
+  stageId?: number | null;
+  dueDate?: string | null;
+  estimatedHours?: number | null;
+  actualHours?: number | null;
+}
+
+export interface UpdateTaskRequest {
+  name?: string;
+  description?: string | null;
+  assignedTo?: number | null;
+  stageId?: number | null;
+  dueDate?: string | null;
+  estimatedHours?: number | null;
+  actualHours?: number | null;
+}
+
+export interface TaskStage {
+  id: number;
+  projectId: number;
+  name: string;
+  sequence: number;
+  isDefault: boolean;
+}
+
+export interface GanttItem {
+  id: number;
+  name: string;
+  stageName: string | null;
+  assignedTo: number | null;
+  dueDate: string | null;
+  estimatedHours: number | null;
+  actualHours: number | null;
+}
+
+export const PROJECT_STATE_LABELS: Record<ProjectState, string> = {
+  PLANNING: 'Planning',
+  IN_PROGRESS: 'In Progress',
+  ON_HOLD: 'On Hold',
+  COMPLETED: 'Completed',
+  CANCELLED: 'Cancelled',
+};
+
+export const PROJECT_STATE_COLORS: Record<ProjectState, string> = {
+  PLANNING: 'blue',
+  IN_PROGRESS: 'processing',
+  ON_HOLD: 'warning',
+  COMPLETED: 'success',
+  CANCELLED: 'default',
+};


### PR DESCRIPTION
## Summary

- Implement full Project Management module: Project List, Project Detail, Gantt chart
- Refactor API client with proactive token refresh every 10 minutes and 403 handling
- Merge CRM routes from `main` into branch

## Changes

### New Files (11)
- `src/types/project.ts` — Project, ProjectTask, TaskStage, GanttItem types
- `src/services/projectService.ts` — 10 API methods (projects CRUD, tasks CRUD, stages, gantt)
- `src/hooks/useProjects.ts` — 5 hooks: useProjects, useProject, useProjectTasks, useProjectStages, useGanttData
- `src/pages/projects/ProjectList/` — Paginated table with search, state filter, create modal, empty state
- `src/pages/projects/ProjectDetail/` — Detail card, state transitions, delete button, task table with stage dropdown, create/edit task modals, empty state
- `src/pages/projects/Gantt/` — Custom CSS timeline Gantt with date axis, bars positioned by due date, width by estimated hours, stage colors, legend

### Modified Files (4)
- `src/api/client.ts` — Add `doRefresh()` helper, proactive 10-min token refresh, intercept 401 and 403
- `src/AppRoutes.tsx` — Add 3 project routes (`/projects`, `/projects/:id`, `/projects/gantt`), merge CRM routes from main
- `src/components/Layout/Sidebar/Sidebar.tsx` — Add Projects navigation link
- `src/hooks/useProjects.ts` — Fix infinite re-render (object params → individual primitives)

## Notes
- Built with custom CSS Gantt (npm registry blocked behind corporate firewall)
- Backend endpoints assumed at `/api/projects`, `/api/projects/*`, `/api/task-stages`
- Requires backend employee seed data for userId=1 (admin) and null stageId handling in task creation