### PR TITLE
fix: Remember Me checkbox now persists tokens in localStorage or sessionStorage accordingly

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3,6 +3,32 @@ import type { AxiosInstance, InternalAxiosRequestConfig } from "axios";
 
 const API_BASE_URL = "/api";
 
+const storages = [localStorage, sessionStorage];
+
+function getTokenFromAny(key: string): string | null {
+  for (const s of storages) {
+    const val = s.getItem(key);
+    if (val) return val;
+  }
+  return null;
+}
+
+function getStorageWithKey(key: string): Storage | null {
+  for (const s of storages) {
+    if (s.getItem(key) !== null) return s;
+  }
+  return null;
+}
+
+function removeFromAll(key: string) {
+  for (const s of storages) s.removeItem(key);
+}
+
+function setOnStorage(key: string, value: string) {
+  const store = getStorageWithKey("erp_token") || getStorageWithKey("erp_refresh_token") || localStorage;
+  store.setItem(key, value);
+}
+
 export const apiClient: AxiosInstance = axios.create({
   baseURL: API_BASE_URL,
   timeout: 30000,
@@ -30,8 +56,7 @@ const processQueue = (error: unknown, token: string | null = null) => {
 
 apiClient.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
-    const token =
-      localStorage.getItem("erp_token") || localStorage.getItem("token");
+    const token = getTokenFromAny("erp_token") || getTokenFromAny("token");
     if (token && config.headers) {
       config.headers.Authorization = `Bearer ${token}`;
     }
@@ -62,14 +87,14 @@ apiClient.interceptors.response.use(
       originalRequest._retry = true;
       isRefreshing = true;
 
-      const refreshToken = localStorage.getItem("erp_refresh_token");
+      const refreshToken = getTokenFromAny("erp_refresh_token");
 
       if (!refreshToken) {
         isRefreshing = false;
-        localStorage.removeItem("erp_token");
-        localStorage.removeItem("erp_refresh_token");
-        localStorage.removeItem("erp_user");
-        localStorage.removeItem("token");
+        removeFromAll("erp_token");
+        removeFromAll("erp_refresh_token");
+        removeFromAll("erp_user");
+        removeFromAll("token");
         window.location.href = "/login";
         return Promise.reject(error);
       }
@@ -82,8 +107,8 @@ apiClient.interceptors.response.use(
 
         if (data.success && data.data) {
           const newToken = data.data.accessToken;
-          localStorage.setItem("erp_token", newToken);
-          localStorage.setItem(
+          setOnStorage("erp_token", newToken);
+          setOnStorage(
             "erp_refresh_token",
             data.data.refreshToken || refreshToken,
           );
@@ -97,10 +122,10 @@ apiClient.interceptors.response.use(
 
       processQueue(error, null);
       isRefreshing = false;
-      localStorage.removeItem("erp_token");
-      localStorage.removeItem("erp_refresh_token");
-      localStorage.removeItem("erp_user");
-      localStorage.removeItem("token");
+      removeFromAll("erp_token");
+      removeFromAll("erp_refresh_token");
+      removeFromAll("erp_user");
+      removeFromAll("token");
       window.location.href = "/login";
     }
     return Promise.reject(error);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -36,9 +36,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     if (response.success && response.data) {
       const { user, accessToken, refreshToken } = response.data;
       setUser(user);
-      localStorage.setItem("erp_token", accessToken);
-      localStorage.setItem("erp_refresh_token", refreshToken);
-      localStorage.setItem("erp_user", JSON.stringify(user));
+      const store = credentials.remember ? localStorage : sessionStorage;
+      store.setItem("erp_token", accessToken);
+      store.setItem("erp_refresh_token", refreshToken);
+      store.setItem("erp_user", JSON.stringify(user));
       return { success: true };
     }
 
@@ -54,6 +55,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     localStorage.removeItem("erp_token");
     localStorage.removeItem("erp_refresh_token");
     localStorage.removeItem("erp_user");
+    sessionStorage.removeItem("erp_token");
+    sessionStorage.removeItem("erp_refresh_token");
+    sessionStorage.removeItem("erp_user");
   }, []);
 
   const value: AuthContextType = {

--- a/src/pages/auth/Login/Login.tsx
+++ b/src/pages/auth/Login/Login.tsx
@@ -35,7 +35,7 @@ export const LoginPage: React.FC = () => {
     
     setLoading(true);
     try {
-      const result = await authContext.login({ email: data.email, password: data.password });
+      const result = await authContext.login({ email: data.email, password: data.password, remember: data.remember });
       
       if (result.success) {
         message.success('Login successful');

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -3,6 +3,7 @@ import { apiClient as api, handleApiError } from "../api/client";
 export interface LoginRequest {
   email: string;
   password: string;
+  remember?: boolean;
 }
 
 export interface AuthUser {
@@ -108,7 +109,7 @@ export const authService = {
   },
 
   getCurrentUser: (): AuthUser | null => {
-    const userStr = localStorage.getItem("erp_user");
+    const userStr = localStorage.getItem("erp_user") || sessionStorage.getItem("erp_user");
     if (userStr) {
       try {
         return JSON.parse(userStr);


### PR DESCRIPTION
## Summary

- The Remember Me checkbox on the login form was decorative — it collected the value but never used it. Tokens were always stored in `localStorage`, persisting across browser closes regardless of the checkbox state.
- Now, when **checked** → tokens stored in `localStorage` (survive browser close). When **unchecked** → tokens stored in `sessionStorage` (cleared when tab closes).

## Changes

- `src/services/authService.ts` — Add `remember?: boolean` to `LoginRequest`; `getCurrentUser()` checks both `localStorage` and `sessionStorage`
- `src/pages/auth/Login/Login.tsx` — Pass `remember` value from the form to `authContext.login()`
- `src/contexts/AuthContext.tsx` — Store tokens in `localStorage` or `sessionStorage` based on the `remember` flag; logout clears both
- `src/api/client.ts` — Read tokens from both storages in request interceptor; during refresh, write new tokens back to the same storage the refresh token came from; clear both storages on auth failure