### PR TITLE
feat: add Helpdesk/Support module with full ticket lifecycle

### DIFF
--- a/issue.md
+++ b/issue.md
@@ -1,0 +1,776 @@
+# Consistency Audit
+
+## Overview
+
+Cross-module audit of the ERP frontend (`src/`) to enforce uniform patterns across all modules. Pages, services, hooks, and types that do the same thing should look the same regardless of which module they belong to.
+
+## Related Issues
+
+| Issue  | Title                   | Relationship                                                |
+| ------ | ----------------------- | ----------------------------------------------------------- |
+| #27    | MVP + Code Consistency  | Superseded by this issue. Close when this is resolved.      |
+| #40    | Fix Orders module       | Partially addressed by Phase 1. Verify on main.             |
+| #41-54 | Various fixes (401-454) | Most are already fixed on `main`. Close after verification. |
+
+## Conventions Source
+
+See `AGENTS.md` for the canonical project conventions. This issue enforces those conventions across all modules.
+
+## Linting
+
+Current ESLint config (`eslint.config.js`) is minimal — only `@eslint/js:recommended`, `typescript-eslint:recommended`, and `react-hooks:recommended`. No custom rules for:
+
+- **Import ordering** — no `import/order` or `simple-import-sort` plugin
+- **Naming conventions** — no `@typescript-eslint/naming-convention` rules
+- **Export style** — no rule enforcing named vs default exports
+- **File structure** — no rule enforcing folder-per-page pattern
+
+**Recommended:** Add `eslint-plugin-simple-import-sort` and `@typescript-eslint/naming-convention` to catch these automatically.
+
+## Current Organizational State
+
+Pages use **3 different organizational patterns**:
+
+| Pattern                  | Modules                                     | Subfolder barrel | Domain barrel |
+| ------------------------ | ------------------------------------------- | :--------------: | :-----------: |
+| **A: Folder + barrel**   | `finance/`, `sales/`                        |      ✅ Yes      |    ✅ Yes     |
+| **B: Folder, no barrel** | `crm/`, `hr/`, `admin/`, `common/`, `auth/` |      ❌ No       |     ❌ No     |
+| **C: Flat files**        | `inventory/`, `purchasing/`                 |    N/A (flat)    |     ❌ No     |
+
+---
+
+## Phase 1 — Bugs (fix now)
+
+### C1: Product/Category `id` typed as string
+
+**Problem:** `Product.id` and `Category.id` are `string`; every other entity ID is `number`.
+
+**Files:**
+
+- `src/types/product.types.ts`
+- `src/types/category.types.ts`
+
+**Fix:** Change `id: string` to `id: number` and update all consumers.
+
+**Consumers to update:**
+
+- `src/services/inventoryService.ts`
+- `src/hooks/useCategories.ts`
+- `src/pages/inventory/ProductListPage.tsx`
+- `src/pages/inventory/ProductDetailsPage.tsx`
+- `src/pages/inventory/CreateProductPage.tsx`
+- `src/pages/inventory/EditProductPage.tsx`
+- `src/pages/inventory/CategoryListPage.tsx`
+
+---
+
+### C2: `salesService.products.search` wrong return type
+
+**Problem:** Returns `Promise<Customer[]>` instead of `Promise<Product[]>`.
+
+**File:** `src/services/salesService.ts:231`
+
+**Fix:** Change return type from `Customer[]` to `Product[]`, generic from `PageResponse<Customer>` to `PageResponse<Product>`.
+
+---
+
+### C3: `useLeads.fetchLeads` empty useCallback deps
+
+**Problem:** `fetchLeads` has empty dependency array `[]` but reads `filters` from closure. Filter changes never trigger a re-fetch.
+
+**File:** `src/hooks/useCRM.ts:18`
+
+**Fix:** Add filter properties to deps array.
+
+---
+
+### C4: Missing `error` state on 7 hooks
+
+**Problem:** Hooks that lack an `error` state variable silently swallow failures. Consumers cannot detect or display errors.
+
+**Affected hooks:**
+
+| Hook                | Current behavior             | Fix                                           |
+| ------------------- | ---------------------------- | --------------------------------------------- |
+| `useLeads`          | Silent catch, resets to `[]` | Add `error` state, store message              |
+| `useLead`           | Silent catch, sets `null`    | Add `error` state, store message              |
+| `usePipelineStages` | Silent catch, resets to `[]` | Add `error` state, store message              |
+| `useCRMDashboard`   | Silent catch, sets `null`    | Add `error` state, store message              |
+| `useCategories`     | Toast-only (`message.error`) | Add `error` state, remove or supplement toast |
+| `usePurchaseOrders` | Toast-only (`message.error`) | Add `error` state, remove or supplement toast |
+| `useSuppliers`      | Toast-only (`message.error`) | Add `error` state, remove or supplement toast |
+
+**Pattern to follow** (from `useAttendance.ts`):
+
+```typescript
+const [error, setError] = useState<string | null>(null);
+
+try {
+  // ... fetch
+} catch (err) {
+  setError(err instanceof Error ? err.message : "Failed to ...");
+} finally {
+  setLoading(false);
+}
+```
+
+---
+
+### C5: CRM hooks use `.then/.catch` instead of async/await
+
+**Files:**
+
+- `src/hooks/useCRM.ts` — `useLead`, `useCRMDashboard`
+
+**Fix:** Convert to async/await with try/catch matching the rest of the codebase.
+
+**Current (inconsistent):**
+
+```typescript
+useEffect(() => {
+  if (!id) return;
+  setLoading(true);
+  crmService
+    .getLead(id)
+    .then(setLead)
+    .catch(() => setLead(null))
+    .finally(() => setLoading(false));
+}, [id]);
+```
+
+**Target (consistent):**
+
+```typescript
+useEffect(() => {
+  if (!id) return;
+  setLoading(true);
+  try {
+    const data = await crmService.getLead(id);
+    setLead(data);
+  } catch (err) {
+    setError(err instanceof Error ? err.message : "Failed to fetch lead");
+  } finally {
+    setLoading(false);
+  }
+}, [id]);
+```
+
+---
+
+## Phase 2 — Structure (one-time refactor)
+
+### S1: Migrate inventory + purchasing from flat files to folder-per-page
+
+**Current (flat):**
+
+```
+src/pages/inventory/ProductListPage.tsx
+src/pages/inventory/ProductDetailsPage.tsx
+src/pages/inventory/CreateProductPage.tsx
+src/pages/inventory/EditProductPage.tsx
+src/pages/inventory/CategoryListPage.tsx
+src/pages/purchasing/SupplierListPage.tsx
+src/pages/purchasing/SupplierDetailsPage.tsx
+src/pages/purchasing/PurchaseOrderListPage.tsx
+src/pages/purchasing/CreatePurchaseOrderPage.tsx
+```
+
+**Target (folders):**
+
+```
+src/pages/inventory/ProductList/ProductList.tsx            + ProductList.module.css + index.ts
+src/pages/inventory/ProductDetails/ProductDetails.tsx      + ProductDetails.module.css + index.ts
+src/pages/inventory/ProductForm/ProductForm.tsx             + index.ts (shared by Create + Edit)
+src/pages/inventory/CategoryList/CategoryList.tsx           + CategoryList.module.css + index.ts
+src/pages/purchasing/SupplierList/SupplierList.tsx          + index.ts
+src/pages/purchasing/SupplierDetails/SupplierDetails.tsx    + index.ts
+src/pages/purchasing/PurchaseOrderList/PurchaseOrderList.tsx + index.ts
+src/pages/purchasing/PurchaseOrderForm/PurchaseOrderForm.tsx + index.ts
+```
+
+**Steps per page:**
+
+1. Create folder matching component name
+2. Move `.tsx` + `.module.css` into folder
+3. Create `index.ts` with `export { Component } from "./Component"` + `export { default } from "./Component"`
+4. Update all import paths referencing the old location
+5. Update `AppRoutes.tsx` imports
+
+---
+
+### S2: Add missing barrel exports
+
+#### Subfolder-level `index.ts`
+
+Every page subfolder should have an `index.ts` following this pattern (used by `finance/` and `sales/`):
+
+```typescript
+export { ComponentName } from "./ComponentName";
+export { default } from "./ComponentName";
+```
+
+**Missing from:**
+
+- `crm/Dashboard/`
+- `crm/LeadsList/`
+- `crm/Pipeline/`
+- `crm/LeadDetails/`
+- `hr/EmployeesList/`
+- `hr/EmployeeDetails/`
+- `hr/Attendance/`
+- `hr/LeaveRequests/`
+- `admin/Users/`
+- `admin/AuditLogs/`
+- `admin/Settings/`
+- `common/Dashboard/`
+- `common/Profile/`
+- `auth/Login/`
+
+#### Domain-level `index.ts`
+
+Every page domain folder should have an `index.ts` re-exporting all sub-pages (following `finance/` and `sales/` pattern):
+
+```typescript
+export { LeadsList } from "./LeadsList";
+export { LeadDetails } from "./LeadDetails";
+export { Pipeline } from "./Pipeline";
+export { CRMDashboard } from "./Dashboard";
+```
+
+**Missing from:**
+
+- `src/pages/crm/`
+- `src/pages/hr/`
+- `src/pages/admin/`
+- `src/pages/common/`
+- `src/pages/auth/`
+- `src/pages/inventory/`
+- `src/pages/purchasing/`
+
+#### Service-level `index.ts`
+
+**Missing:** `src/services/index.ts` should re-export all services.
+
+---
+
+### S3: Fix `types/index.ts` barrel
+
+**Current (incomplete):**
+
+```typescript
+export * from "./product.types";
+export * from "./category.types";
+export * from "./supplier.types";
+export * from "./purchaseOrder.types";
+```
+
+**Target (complete):**
+
+```typescript
+export * from "./product.types";
+export * from "./category.types";
+export * from "./supplier.types";
+export * from "./purchaseOrder.types";
+export * from "./crm";
+export * from "./finance";
+export * from "./hr";
+export * from "./sales";
+```
+
+---
+
+### S4: Standardize type file naming
+
+**Problem:** Half use `.types.ts` suffix, half use bare `.ts`.
+
+`.types.ts` suffix (Inventory/Purchasing domain):
+
+- `product.types.ts`
+- `category.types.ts`
+- `supplier.types.ts`
+- `purchaseOrder.types.ts`
+
+Bare `.ts` (CRM, Finance, HR, Sales domain):
+
+- `crm.ts`
+- `finance.ts`
+- `hr.ts`
+- `sales.ts`
+
+**Decision needed:** Choose one convention. Recommend `.ts` (shorter, matches page/service naming).
+
+---
+
+## Phase 3 — API Layer (services)
+
+### A1: Standardize API client alias
+
+**Problem:** 4 services use `apiClient` directly, 7 alias as `api`.
+
+| Style                         | Services                                                                                                                   |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `import { apiClient }`        | `crmService`, `dashboardService`, `financeService`, `salesService`                                                         |
+| `import { apiClient as api }` | `authService`, `hrService`, `inventoryService`, `purchasingService`, `settingsService`, `usersService`, `auditLogsService` |
+
+**Decision needed:** Pick one. Recommend `apiClient` (self-documenting, no alias needed).
+
+---
+
+### A2: Migrate 5 services to centralized `endpoints` object
+
+**Problem:** `authService`, `hrService`, `settingsService`, `usersService`, `auditLogsService` hardcode path strings instead of using the centralized `endpoints` object.
+
+**Current (inline):**
+
+```typescript
+const response = await api.post("/v1/auth/login", credentials);
+```
+
+**Target (via endpoints):**
+
+```typescript
+const response = await apiClient.post(endpoints.auth.login, credentials);
+```
+
+The centralized `endpoints.ts` file already defines endpoints for all modules. These 5 services just need to be updated to reference it.
+
+**Files to update:**
+
+- `src/services/authService.ts` — endpoints `auth.login`, `auth.refresh`, `auth.logout`
+- `src/services/hrService.ts` — endpoints `employees.*`, `attendance.*`, `leave.*`
+- `src/services/settingsService.ts` — endpoints `settings.*`
+- `src/services/usersService.ts` — endpoints `users.*`
+- `src/services/auditLogsService.ts` — endpoints `auditLogs.*`
+
+**Note:** `endpoints.ts` may need new sections added for auth and settings if they don't exist yet.
+
+---
+
+### A3: Unify error handling
+
+**Problem:** Three error handling strategies coexist:
+
+| Strategy            | Services                                                                               | Behavior                                                           |
+| ------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| **Throw**           | `dashboardService`, `hrService`, `settingsService`, `usersService`, `auditLogsService` | `try/catch` → `throw new Error(handleApiError(error))`             |
+| **Return object**   | `authService`                                                                          | `try/catch` → returns `{ success: false, error: ... }`             |
+| **Mixed / Swallow** | `financeService`, `salesService`                                                       | Some methods `console.error` + return null/[], others no try/catch |
+| **No handling**     | `crmService`, `inventoryService`, `purchasingService`                                  | No try/catch, errors propagate                                     |
+
+**Decision needed:** Recommend **throw pattern** (used by 5 services and the most defensive):
+
+```typescript
+try {
+  const response = await apiClient.get(...);
+  return response.data.data;
+} catch (error) {
+  throw new Error(handleApiError(error));
+}
+```
+
+---
+
+### A4: Extract shared API response types
+
+**Problem:** `ApiResponse<T>` and `PageResponse<T>` are defined identically in both `financeService.ts` and `salesService.ts`.
+
+**Fix:** Extract to `src/types/api.ts`:
+
+```typescript
+export interface ApiResponse<T> {
+  success: boolean;
+  message?: string;
+  data: T;
+  timestamp?: string;
+}
+
+export interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+  first: boolean;
+  last: boolean;
+}
+```
+
+Then import in all services:
+
+```typescript
+import type { ApiResponse, PageResponse } from "../types/api";
+```
+
+---
+
+### A5: Normalize pagination return shape
+
+**Problem:** Services return different pagination shapes:
+
+| Service             | Return shape                                                    |
+| ------------------- | --------------------------------------------------------------- |
+| `financeService`    | `{ items: T[]; total: number }`                                 |
+| `salesService`      | `{ items: T[]; total: number; page: number; pageSize: number }` |
+| `crmService`        | `{ data: T[]; total: number }`                                  |
+| `inventoryService`  | `{ data: T[]; total: number }`                                  |
+| `purchasingService` | `{ data: T[]; total: number }`                                  |
+| `hrService`         | `{ content: T[]; totalElements: number }`                       |
+| `usersService`      | `{ content: T[]; totalElements: number }`                       |
+| `auditLogsService`  | `{ content: T[]; totalElements: number }`                       |
+
+**Decision needed:** Standardize on one shape. Recommend `{ items: T[]; total: number }` (used by finance/sales, shortest, no unnecessary metadata).
+
+---
+
+### A6: Unified service export style
+
+**Problem:** 8 services use `export default`, 3 use named export only.
+
+| Style             | Services                                                                                                                                      |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `export default`  | `auditLogsService`, `settingsService`, `inventoryService`, `crmService`, `hrService`, `usersService`, `dashboardService`, `purchasingService` |
+| Named export only | `authService`, `financeService`, `salesService` (also define `ApiResponse`/`PageResponse` locally)                                            |
+
+**Decision needed:** Pick one. Recommend **named export only** (`export const financeService = { ... }` without `export default financeService`) to match how pages and components export.
+
+### A7: Remove dead `src/services/apiClient.ts`
+
+**Problem:** This file exists but no service imports it. It defines an axios instance at `/api/v1` (different from the real one at `/api`) and re-exports from `../api/client` as a fallback.
+
+**Fix:** Delete the file after confirming no imports reference it.
+
+---
+
+### A8: Move inline type definitions to `src/types/`
+
+**Problem:** 6 services define types inline instead of in the centralized `src/types/` directory:
+
+| Service               | Types defined inline                                                         |
+| --------------------- | ---------------------------------------------------------------------------- |
+| `authService.ts`      | `LoginRequest`, `AuthUser`, `LoginResponse`                                  |
+| `dashboardService.ts` | `DashboardStats`, `BackendStats`                                             |
+| `hrService.ts`        | `CreateEmployeeRequest`, `UpdateEmployeeRequest` (some are in `types/hr.ts`) |
+| `settingsService.ts`  | `CompanySettings`                                                            |
+| `usersService.ts`     | `User`, `CreateUserDto`, `UpdateUserDto`, `UserFilters`, `UsersResponse`     |
+| `auditLogsService.ts` | `AuditLog`, `AuditLogFilters`, `AuditLogsResponse`                           |
+
+**Fix:** Move each to the appropriate `src/types/<module>.ts` file and import back in the service.
+
+---
+
+## Phase 4 — Hooks (hook layer consistency)
+
+### H1: Standardize return data field to `data`
+
+**Problem:** 10 hooks use `data` as the return field name, 7 use domain-specific names.
+
+| Convention                 | Hooks                                                                                                                                                             |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data`                     | `useAttendance`, `useAuditLogs`, `useCustomer`, `useEmployees`, `useInvoices`, `useJournalEntries`, `useLeaveRequests`, `useLeaveBalances`, `useUsers`, `useUser` |
+| `leads` / `lead`           | `useLeads`, `useLead`                                                                                                                                             |
+| `categories`               | `useCategories`                                                                                                                                                   |
+| `orders`                   | `usePurchaseOrders`                                                                                                                                               |
+| `suppliers`                | `useSuppliers`                                                                                                                                                    |
+| `stages` / `opportunities` | `usePipelineStages`                                                                                                                                               |
+| `stats`                    | `useCRMDashboard`                                                                                                                                                 |
+
+**Fix:** Rename all domain-specific names to `data`. This enables generic table components that work with any hook.
+
+---
+
+### H2: Standardize refetch naming to `refetch`
+
+**Problem:**
+
+| Name              | Hooks                                                                                                                                                             |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `refetch`         | `useAttendance`, `useAuditLogs`, `useCustomer`, `useEmployees`, `useInvoices`, `useJournalEntries`, `useLeaveRequests`, `useLeaveBalances`, `useUsers`, `useUser` |
+| `fetchLeads`      | `useLeads`                                                                                                                                                        |
+| `fetchCategories` | `useCategories`                                                                                                                                                   |
+| `fetchOrders`     | `usePurchaseOrders`                                                                                                                                               |
+| `fetchSuppliers`  | `useSuppliers`                                                                                                                                                    |
+| `refresh`         | `usePipelineStages`                                                                                                                                               |
+
+**Fix:** Rename all to `refetch`.
+
+---
+
+### H3: Fix loading initialization
+
+**Problem:** Hooks that auto-fetch on mount but initialize `loading: false` have a brief render cycle where `loading === false` even though the fetch hasn't completed.
+
+**Wrong:**
+
+```typescript
+const [loading, setLoading] = useState(false);
+useEffect(() => {
+  fetchData();
+}, []);
+```
+
+**Right:**
+
+```typescript
+const [loading, setLoading] = useState(true);
+useEffect(() => {
+  fetchData();
+}, []);
+```
+
+**Affected hooks:** `useLeads`, `useLead`, `usePipelineStages`, `useCRMDashboard`, `useCategories`, `usePurchaseOrders`, `useSuppliers`
+
+---
+
+### H4: Add try/catch to mutation functions
+
+**Problem:** Mutation functions in several hooks lack error handling. Errors become unhandled promise rejections.
+
+**Affected:**
+
+| Hook           | Functions missing try/catch                          |
+| -------------- | ---------------------------------------------------- |
+| `useLeads`     | `createLead`                                         |
+| `useEmployees` | `createEmployee`, `updateEmployee`, `deleteEmployee` |
+
+**Fix:** Wrap in try/catch, set error state, re-throw or return error.
+
+---
+
+### H5: Add null/undefined fallbacks
+
+**Problem:** Most hooks access `response.content` / `response.data` / `response.items` without null fallbacks. If the backend returns `undefined`, the consumer crashes on `.map()`.
+
+**Affected:** Every hook except `useAttendance`, `useLeaveRequests`, `useLeaveBalances`.
+
+**Fix:**
+
+```typescript
+// Instead of:
+setData(response.content);
+
+// Use:
+setData(response.content ?? []);
+setTotal(response.totalElements ?? 0);
+```
+
+---
+
+## Phase 5 — Cosmetic (naming & imports)
+
+### N1: Fix component name / filename mismatches
+
+| File                            | Component name   | Should be                         |
+| ------------------------------- | ---------------- | --------------------------------- |
+| `hr/Attendance/Attendance.tsx`  | `AttendancePage` | `Attendance`                      |
+| `admin/Users/Users.tsx`         | `UsersListPage`  | `Users`                           |
+| `admin/AuditLogs/AuditLogs.tsx` | `AuditLogsPage`  | `AuditLogs`                       |
+| `admin/Settings/Settings.tsx`   | `SettingsPage`   | `Settings`                        |
+| `common/Profile/Profile.tsx`    | `ProfilePage`    | `Profile`                         |
+| `auth/Login/Login.tsx`          | `LoginPage`      | `Login`                           |
+| `crm/Dashboard/Dashboard.tsx`   | `CRMDashboard`   | `Dashboard` (namespace in barrel) |
+
+**OR** (alternative): Rename the files to match the component names.
+
+---
+
+### N2: Add missing `import React`
+
+**Files missing `import React` (uses JSX without it):**
+
+- `crm/Dashboard/Dashboard.tsx`
+- `crm/Pipeline/Pipeline.tsx`
+- `admin/Users/Users.tsx`
+- `hr/LeaveRequests/LeaveRequests.tsx`
+
+**Note:** React 17+ JSX transform may not require this, but for consistency with the rest of the codebase (which does import React), add the import.
+
+---
+
+### N3: Enforce consistent import ordering
+
+**Standard pattern (from `finance/` and `sales/`):**
+
+```
+1. React                    import React, { useState } from "react";
+2. Router                   import { useNavigate } from "react-router-dom";
+3. Third-party libs         import { Button, Card } from "antd";
+4. Icons                    import { PlusOutlined } from "@ant-design/icons";
+5. Local components         import { DataTable } from "../../../components/common";
+6. Local hooks              import { useInvoices } from "../../../hooks";
+7. Types                    import type { Invoice } from "../../../types/finance";
+8. Styles (last)            import styles from "./X.module.css";
+```
+
+**Files to fix:** All pages in `crm/`, `hr/`, `admin/`, `auth/`, `inventory/`, `purchasing/`.
+
+---
+
+## Execution Plan
+
+```
+Phase 1 ─ Bugs (5 items)
+  [ ] C1  Product/Category id string→number
+  [ ] C2  salesService.products.search return type
+  [ ] C3  useLeads useCallback deps
+  [ ] C4  Add error state to 7 hooks
+  [ ] C5  CRM hooks → async/await
+
+Phase 2 ─ Structure (4 items)
+  [ ] S1  inventory + purchasing flat→folder
+  [ ] S2  Add barrel exports (all missing index.ts)
+  [ ] S3  Fix types/index.ts barrel
+  [ ] S4  Standardize type file naming
+
+Phase 3 ─ API Layer (8 items)
+  [ ] A1  Standardize apiClient alias
+  [ ] A2  Migrate 5 services to endpoints object
+  [ ] A3  Unify error handling to throw pattern
+  [ ] A4  Extract ApiResponse/PageResponse to shared
+  [ ] A5  Normalize pagination return shape
+  [ ] A6  Unified service export style
+  [ ] A7  Remove dead apiClient.ts
+  [ ] A8  Move inline types to types/
+
+Phase 4 ─ Hooks (5 items)
+  [ ] H1  Standardize return data field to `data`
+  [ ] H2  Standardize refetch to `refetch`
+  [ ] H3  Fix loading init values
+  [ ] H4  Add try/catch to mutation functions
+  [ ] H5  Add null/undefined fallbacks
+
+Phase 5 ─ Polish (3 items)
+  [ ] N1  Fix component name mismatches
+  [ ] N2  Add missing React imports
+  [ ] N3  Enforce consistent import order
+```
+
+---
+
+## Definition of Done
+
+This issue is complete when:
+
+1. **No flat files** — every page in `inventory/` and `purchasing/` lives in its own folder with `index.ts`
+2. **Every subfolder has a barrel** — all page folders export via `index.ts`
+3. **Every domain has a barrel** — all page domains have `index.ts` re-exporting sub-pages
+4. **Services barrel** — `src/services/index.ts` re-exports all services
+5. **Types barrel** — `src/types/index.ts` re-exports all 9 type files
+6. **All services use `endpoints` object** — no hardcoded path strings
+7. **All services use same error handling** — throw pattern with `handleApiError`
+8. **All hooks return `{ data, loading, error, total, refetch }`** — no domain-specific names
+9. **All hooks initialize `loading: true`** — no loading flash on auto-fetch
+10. **All hooks have `error` state** — no silent failures
+11. **All IDs are `number`** — no `string` IDs in Product/Category
+12. **All component names match filenames** — no `Page` suffix mismatches
+13. **Dead code removed** — `src/services/apiClient.ts` deleted
+14. **`ApiResponse<T>` / `PageResponse<T>` shared** — extracted to `src/types/api.ts`
+15. **TypeScript compiles with 0 errors**
+16. **Build passes with 0 warnings**
+
+---
+
+## Appendix: Full File Inventory
+
+### Pages (28 files)
+
+```
+admin/
+  AuditLogs/AuditLogs.tsx
+  Settings/Settings.tsx
+  Users/Users.tsx
+auth/
+  Login/Login.tsx
+common/
+  Dashboard/Dashboard.tsx
+  Profile/Profile.tsx
+crm/
+  Dashboard/Dashboard.tsx
+  LeadDetails/LeadDetails.tsx
+  LeadsList/LeadsList.tsx
+  Pipeline/Pipeline.tsx
+finance/
+  ChartOfAccounts/ChartOfAccounts.tsx
+  InvoiceDetails/InvoiceDetails.tsx
+  InvoiceForm/InvoiceForm.tsx
+  InvoicesList/InvoicesList.tsx
+  JournalEntries/JournalEntries.tsx
+  JournalEntryForm/JournalEntryForm.tsx
+hr/
+  Attendance/Attendance.tsx
+  EmployeeDetails/EmployeeDetails.tsx
+  EmployeesList/EmployeesList.tsx
+  LeaveRequests/LeaveRequests.tsx
+inventory/
+  CategoryListPage.tsx
+  CreateProductPage.tsx
+  EditProductPage.tsx
+  ProductDetailsPage.tsx
+  ProductListPage.tsx
+projects/
+  ProjectDetail/ProjectDetail.tsx
+  ProjectList/ProjectList.tsx
+purchasing/
+  CreatePurchaseOrderPage.tsx
+  PurchaseOrderListPage.tsx
+  SupplierDetailsPage.tsx
+  SupplierListPage.tsx
+sales/
+  CustomerDetails/CustomerDetails.tsx
+  CustomersList/CustomersList.tsx
+  SalesOrderDetails/SalesOrderDetails.tsx
+  SalesOrderForm/SalesOrderForm.tsx
+  SalesOrdersList/SalesOrdersList.tsx
+```
+
+### Services (11 files)
+
+```
+services/
+  apiClient.ts          ← DEAD - not imported by anything
+  auditLogsService.ts
+  authService.ts
+  crmService.ts
+  dashboardService.ts
+  financeService.ts
+  hrService.ts
+  inventoryService.ts
+  projectService.ts
+  purchasingService.ts
+  salesService.ts
+  settingsService.ts
+  usersService.ts
+```
+
+### Hooks (12 files)
+
+```
+hooks/
+  useAttendance.ts
+  useAuditLogs.ts
+  useCRM.ts
+  useCategories.ts
+  useCustomer.ts
+  useEmployees.ts
+  useInvoices.ts
+  useJournalEntries.ts
+  useLeaveRequests.ts
+  useProjects.ts
+  usePurchaseOrders.ts
+  useSuppliers.ts
+  useUsers.ts
+```
+
+### Types (9 files)
+
+```
+types/
+  category.types.ts
+  crm.ts
+  finance.ts
+  hr.ts
+  index.ts              ← INCOMPLETE - only 4 of 9 re-exported
+  product.types.ts
+  purchaseOrder.types.ts
+  sales.ts
+  supplier.types.ts
+```

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -38,7 +38,12 @@ import CRMDashboard from "./pages/crm/Dashboard/Dashboard";
 import LeadsList from "./pages/crm/LeadsList/LeadsList";
 import { Pipeline } from "./pages/crm/Pipeline/Pipeline";
 import LeadDetails from "./pages/crm/LeadDetails/LeadDetails";
-import { TicketsList, CreateTicket, TicketDetails } from "./pages/support";
+import {
+  TicketsList,
+  CreateTicket,
+  TicketDetails,
+  EditTicket,
+} from "./pages/support";
 
 export const AppRoutes = () => {
   return (
@@ -102,6 +107,7 @@ export const AppRoutes = () => {
         <Route path="/support/tickets" element={<TicketsList />} />
         <Route path="/support/tickets/new" element={<CreateTicket />} />
         <Route path="/support/tickets/:id" element={<TicketDetails />} />
+        <Route path="/support/tickets/:id/edit" element={<EditTicket />} />
 
         {/* Purchasing routes */}
         <Route path="/purchasing/suppliers" element={<SupplierListPage />} />

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -38,6 +38,7 @@ import CRMDashboard from "./pages/crm/Dashboard/Dashboard";
 import LeadsList from "./pages/crm/LeadsList/LeadsList";
 import { Pipeline } from "./pages/crm/Pipeline/Pipeline";
 import LeadDetails from "./pages/crm/LeadDetails/LeadDetails";
+import { TicketsList, CreateTicket, TicketDetails } from "./pages/support";
 
 export const AppRoutes = () => {
   return (
@@ -96,6 +97,11 @@ export const AppRoutes = () => {
         <Route path="/crm/leads" element={<LeadsList />} />
         <Route path="/crm/pipeline" element={<Pipeline />} />
         <Route path="/crm/leads/:id" element={<LeadDetails />} />
+
+        {/* Support routes */}
+        <Route path="/support/tickets" element={<TicketsList />} />
+        <Route path="/support/tickets/new" element={<CreateTicket />} />
+        <Route path="/support/tickets/:id" element={<TicketDetails />} />
 
         {/* Purchasing routes */}
         <Route path="/purchasing/suppliers" element={<SupplierListPage />} />

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -117,6 +117,13 @@ export const endpoints = {
     opportunities: "/v1/crm/opportunities",
     opportunityStage: (id: number) => `/v1/crm/opportunities/${id}/stage`,
   },
+  support: {
+    list: "/v1/support/tickets",
+    getById: (id: number) => `/v1/support/tickets/${id}`,
+    create: "/v1/support/tickets",
+    update: (id: number) => `/v1/support/tickets/${id}`,
+    delete: (id: number) => `/v1/support/tickets/${id}`,
+  },
   dashboard: {
     stats: "/v1/dashboard/stats",
   },

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -123,6 +123,7 @@ export const endpoints = {
     create: "/v1/support/tickets",
     update: (id: number) => `/v1/support/tickets/${id}`,
     delete: (id: number) => `/v1/support/tickets/${id}`,
+    addComment: (id: number) => `/v1/support/tickets/${id}/comments`,
   },
   dashboard: {
     stats: "/v1/dashboard/stats",

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   FileTextOutlined,
   TeamOutlined,
   SettingOutlined,
+  CustomerServiceOutlined,
   LogoutOutlined,
 } from "@ant-design/icons";
 import { AuthContext } from "../../../contexts/AuthContext";
@@ -115,6 +116,18 @@ export const Sidebar: React.FC<{ collapsed?: boolean }> = ({
       ],
     },
     {
+      key: "support",
+      icon: <CustomerServiceOutlined />,
+      label: "Support",
+      children: [
+        {
+          key: "tickets",
+          label: "Tickets",
+          onClick: () => navigate("/support/tickets"),
+        },
+      ],
+    },
+    {
       key: "hr",
       icon: <TeamOutlined />,
       label: "HR",
@@ -178,6 +191,7 @@ export const Sidebar: React.FC<{ collapsed?: boolean }> = ({
     if (path.startsWith("/finance/invoices")) return "invoices";
     if (path.startsWith("/finance/journal")) return "journal";
     if (path.startsWith("/finance/accounts")) return "accounts";
+    if (path.startsWith("/support/tickets")) return "tickets";
     if (path.startsWith("/hr/employees")) return "employees";
     if (path.startsWith("/hr/attendance")) return "attendance";
     if (path.startsWith("/hr/leave")) return "leave";
@@ -201,6 +215,7 @@ export const Sidebar: React.FC<{ collapsed?: boolean }> = ({
       invoices: "finance",
       journal: "finance",
       accounts: "finance",
+      tickets: "support",
       employees: "hr",
       attendance: "hr",
       leave: "hr",
@@ -242,7 +257,7 @@ export const Sidebar: React.FC<{ collapsed?: boolean }> = ({
           role="button"
           tabIndex={0}
           onKeyDown={(e) => e.key === "Enter" && logout?.()}
-          style={{ display: collapsed ? 'none' : 'flex' }}
+          style={{ display: collapsed ? "none" : "flex" }}
         >
           <LogoutOutlined />
           {!collapsed && <span>Logout</span>}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -18,4 +18,9 @@ export { useInvoice } from "./useInvoice";
 export { useAccounts } from "./useAccounts";
 export { useJournalEntries } from "./useJournalEntries";
 export { useJournalEntry } from "./useJournalEntry";
-export { useTickets, useTicket, useCreateTicket } from "./useSupport";
+export {
+  useTickets,
+  useTicket,
+  useCreateTicket,
+  useUpdateTicket,
+} from "./useSupport";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -18,3 +18,4 @@ export { useInvoice } from "./useInvoice";
 export { useAccounts } from "./useAccounts";
 export { useJournalEntries } from "./useJournalEntries";
 export { useJournalEntry } from "./useJournalEntry";
+export { useTickets, useTicket, useCreateTicket } from "./useSupport";

--- a/src/hooks/useSupport.ts
+++ b/src/hooks/useSupport.ts
@@ -1,5 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
-import type { Ticket, TicketFilters, CreateTicketDto } from "../types/support";
+import type {
+  Ticket,
+  TicketFilters,
+  CreateTicketDto,
+  UpdateTicketDto,
+} from "../types/support";
 import { supportService } from "../services/supportService";
 
 export const useTickets = (filters: TicketFilters = {}) => {
@@ -79,4 +84,30 @@ export const useCreateTicket = () => {
   }, []);
 
   return { createTicket, loading, error };
+};
+
+export const useUpdateTicket = () => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateTicket = useCallback(
+    async (id: number, data: UpdateTicketDto) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const ticket = await supportService.update(id, data);
+        return ticket;
+      } catch (err) {
+        const msg =
+          err instanceof Error ? err.message : "Failed to update ticket";
+        setError(msg);
+        throw err;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
+  return { updateTicket, loading, error };
 };

--- a/src/hooks/useSupport.ts
+++ b/src/hooks/useSupport.ts
@@ -1,0 +1,82 @@
+import { useState, useEffect, useCallback } from "react";
+import type { Ticket, TicketFilters, CreateTicketDto } from "../types/support";
+import { supportService } from "../services/supportService";
+
+export const useTickets = (filters: TicketFilters = {}) => {
+  const [data, setData] = useState<Ticket[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async (f: TicketFilters = filters) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await supportService.getAll(f);
+      setData(result.data);
+      setTotal(result.total);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch tickets");
+      setData([]);
+      setTotal(0);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { data, total, loading, error, refetch };
+};
+
+export const useTicket = (id: number) => {
+  const [data, setData] = useState<Ticket | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await supportService.getById(id);
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch ticket");
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { data, loading, error, refetch };
+};
+
+export const useCreateTicket = () => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const createTicket = useCallback(async (data: CreateTicketDto) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const ticket = await supportService.create(data);
+      return ticket;
+    } catch (err) {
+      const msg =
+        err instanceof Error ? err.message : "Failed to create ticket";
+      setError(msg);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { createTicket, loading, error };
+};

--- a/src/pages/support/CreateTicket/CreateTicket.module.css
+++ b/src/pages/support/CreateTicket/CreateTicket.module.css
@@ -1,0 +1,4 @@
+.backButton {
+  margin-bottom: 16px;
+  display: block;
+}

--- a/src/pages/support/CreateTicket/CreateTicket.tsx
+++ b/src/pages/support/CreateTicket/CreateTicket.tsx
@@ -1,0 +1,148 @@
+import React, { useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Card,
+  Form,
+  Input,
+  Select,
+  Button,
+  Typography,
+  message,
+  Space,
+} from "antd";
+import { ArrowLeftOutlined } from "@ant-design/icons";
+import { useCreateTicket } from "../../../hooks/useSupport";
+import { salesService } from "../../../services/salesService";
+import type { CreateTicketDto } from "../../../types/support";
+import type { Customer } from "../../../types/sales";
+import styles from "./CreateTicket.module.css";
+
+const { Title } = Typography;
+const { TextArea } = Input;
+
+export const CreateTicket: React.FC = () => {
+  const navigate = useNavigate();
+  const [form] = Form.useForm<CreateTicketDto>();
+  const { createTicket, loading } = useCreateTicket();
+  const [customerOptions, setCustomerOptions] = useState<
+    { value: number; label: string }[]
+  >([]);
+  const [searching, setSearching] = useState(false);
+
+  const handleCustomerSearch = useCallback(async (query: string) => {
+    if (!query) {
+      setCustomerOptions([]);
+      return;
+    }
+    setSearching(true);
+    try {
+      const result = await salesService.customers.getAll({
+        search: query,
+        size: 20,
+      });
+      setCustomerOptions(
+        (result.items as Customer[]).map((c) => ({
+          value: c.id,
+          label: `${c.name} (ID: ${c.id})`,
+        })),
+      );
+    } catch {
+      setCustomerOptions([]);
+    } finally {
+      setSearching(false);
+    }
+  }, []);
+
+  const handleSubmit = async (values: CreateTicketDto) => {
+    try {
+      const ticket = await createTicket(values);
+      message.success("Ticket created");
+      navigate(`/support/tickets/${ticket.id}`);
+    } catch {
+      message.error("Failed to create ticket");
+    }
+  };
+
+  return (
+    <div>
+      <Space className={styles.backButton}>
+        <Button
+          icon={<ArrowLeftOutlined />}
+          onClick={() => navigate("/support/tickets")}
+        >
+          Back to Tickets
+        </Button>
+      </Space>
+
+      <Card>
+        <Title level={4}>Create New Ticket</Title>
+        <Form
+          form={form}
+          layout="vertical"
+          onFinish={handleSubmit}
+          initialValues={{ priority: "MEDIUM" }}
+          style={{ maxWidth: 600 }}
+        >
+          <Form.Item
+            name="title"
+            label="Title"
+            rules={[{ required: true, message: "Please enter a title" }]}
+          >
+            <Input placeholder="Brief description of the issue" />
+          </Form.Item>
+
+          <Form.Item name="description" label="Description">
+            <TextArea
+              rows={4}
+              placeholder="Detailed description of the issue"
+            />
+          </Form.Item>
+
+          <Form.Item
+            name="customerId"
+            label="Customer"
+            rules={[{ required: true, message: "Please select a customer" }]}
+          >
+            <Select
+              showSearch
+              placeholder="Search customer by name..."
+              filterOption={false}
+              onSearch={handleCustomerSearch}
+              options={customerOptions}
+              loading={searching}
+              notFoundContent={null}
+            />
+          </Form.Item>
+
+          <Form.Item
+            name="priority"
+            label="Priority"
+            rules={[{ required: true, message: "Please select a priority" }]}
+          >
+            <Select
+              options={[
+                { value: "LOW", label: "Low" },
+                { value: "MEDIUM", label: "Medium" },
+                { value: "HIGH", label: "High" },
+                { value: "URGENT", label: "Urgent" },
+              ]}
+            />
+          </Form.Item>
+
+          <Form.Item>
+            <Space>
+              <Button type="primary" htmlType="submit" loading={loading}>
+                Submit
+              </Button>
+              <Button onClick={() => navigate("/support/tickets")}>
+                Cancel
+              </Button>
+            </Space>
+          </Form.Item>
+        </Form>
+      </Card>
+    </div>
+  );
+};
+
+export default CreateTicket;

--- a/src/pages/support/CreateTicket/CreateTicket.tsx
+++ b/src/pages/support/CreateTicket/CreateTicket.tsx
@@ -13,8 +13,10 @@ import {
 import { ArrowLeftOutlined } from "@ant-design/icons";
 import { useCreateTicket } from "../../../hooks/useSupport";
 import { salesService } from "../../../services/salesService";
+import { hrService } from "../../../services/hrService";
 import type { CreateTicketDto } from "../../../types/support";
 import type { Customer } from "../../../types/sales";
+import type { Employee } from "../../../types/hr";
 import styles from "./CreateTicket.module.css";
 
 const { Title } = Typography;
@@ -28,6 +30,10 @@ export const CreateTicket: React.FC = () => {
     { value: number; label: string }[]
   >([]);
   const [searching, setSearching] = useState(false);
+  const [employeeOptions, setEmployeeOptions] = useState<
+    { value: number; label: string }[]
+  >([]);
+  const [searchingEmployee, setSearchingEmployee] = useState(false);
 
   const handleCustomerSearch = useCallback(async (query: string) => {
     if (!query) {
@@ -50,6 +56,31 @@ export const CreateTicket: React.FC = () => {
       setCustomerOptions([]);
     } finally {
       setSearching(false);
+    }
+  }, []);
+
+  const handleEmployeeSearch = useCallback(async (query: string) => {
+    if (!query) {
+      setEmployeeOptions([]);
+      return;
+    }
+    setSearchingEmployee(true);
+    try {
+      const result = await hrService.employees.getAll({
+        search: query,
+        size: 20,
+      });
+      const employees: Employee[] = result.content || [];
+      setEmployeeOptions(
+        employees.map((e) => ({
+          value: e.id,
+          label: `${e.fullName} (${e.department})`,
+        })),
+      );
+    } catch {
+      setEmployeeOptions([]);
+    } finally {
+      setSearchingEmployee(false);
     }
   }, []);
 
@@ -126,6 +157,19 @@ export const CreateTicket: React.FC = () => {
                 { value: "HIGH", label: "High" },
                 { value: "URGENT", label: "Urgent" },
               ]}
+            />
+          </Form.Item>
+
+          <Form.Item name="assignedTo" label="Assigned To">
+            <Select
+              showSearch
+              placeholder="Search employee..."
+              filterOption={false}
+              onSearch={handleEmployeeSearch}
+              options={employeeOptions}
+              loading={searchingEmployee}
+              allowClear
+              notFoundContent={null}
             />
           </Form.Item>
 

--- a/src/pages/support/CreateTicket/index.ts
+++ b/src/pages/support/CreateTicket/index.ts
@@ -1,0 +1,2 @@
+export { CreateTicket } from "./CreateTicket";
+export { default } from "./CreateTicket";

--- a/src/pages/support/EditTicket/EditTicket.module.css
+++ b/src/pages/support/EditTicket/EditTicket.module.css
@@ -1,0 +1,13 @@
+.backButton {
+  margin-bottom: 16px;
+  display: block;
+}
+
+.loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  gap: 16px;
+}

--- a/src/pages/support/EditTicket/EditTicket.tsx
+++ b/src/pages/support/EditTicket/EditTicket.tsx
@@ -1,0 +1,175 @@
+import React, { useState, useCallback } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  Card,
+  Form,
+  Input,
+  Select,
+  Button,
+  Typography,
+  message,
+  Space,
+  Spin,
+} from "antd";
+import { ArrowLeftOutlined } from "@ant-design/icons";
+import { useTicket, useUpdateTicket } from "../../../hooks/useSupport";
+import { hrService } from "../../../services/hrService";
+import type { UpdateTicketDto } from "../../../types/support";
+import type { Employee } from "../../../types/hr";
+import styles from "./EditTicket.module.css";
+
+const { Title } = Typography;
+const { TextArea } = Input;
+
+export const EditTicket: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const ticketId = Number(id);
+  const { data: ticket, loading: fetching } = useTicket(ticketId);
+  const { updateTicket, loading: saving } = useUpdateTicket();
+  const [form] = Form.useForm<UpdateTicketDto>();
+  const [employeeOptions, setEmployeeOptions] = useState<
+    { value: number; label: string }[]
+  >([]);
+  const [searching, setSearching] = useState(false);
+
+  const handleEmployeeSearch = useCallback(async (query: string) => {
+    if (!query) {
+      setEmployeeOptions([]);
+      return;
+    }
+    setSearching(true);
+    try {
+      const result = await hrService.employees.getAll({
+        search: query,
+        size: 20,
+      });
+      const employees: Employee[] = result.content || [];
+      setEmployeeOptions(
+        employees.map((e) => ({
+          value: e.id,
+          label: `${e.fullName} (${e.department})`,
+        })),
+      );
+    } catch {
+      setEmployeeOptions([]);
+    } finally {
+      setSearching(false);
+    }
+  }, []);
+
+  if (fetching) {
+    return (
+      <div className={styles.loading}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (!ticket) {
+    return (
+      <div className={styles.loading}>
+        <Typography.Text type="danger">Ticket not found</Typography.Text>
+        <br />
+        <Button onClick={() => navigate("/support/tickets")}>
+          Back to Tickets
+        </Button>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (values: UpdateTicketDto) => {
+    try {
+      await updateTicket(ticketId, values);
+      message.success("Ticket updated");
+      navigate(`/support/tickets/${ticketId}`);
+    } catch {
+      message.error("Failed to update ticket");
+    }
+  };
+
+  return (
+    <div>
+      <Space className={styles.backButton}>
+        <Button
+          icon={<ArrowLeftOutlined />}
+          onClick={() => navigate(`/support/tickets/${ticketId}`)}
+        >
+          Back to Ticket
+        </Button>
+      </Space>
+
+      <Card>
+        <Title level={4}>Edit Ticket #{ticket.id}</Title>
+        <Form
+          form={form}
+          layout="vertical"
+          onFinish={handleSubmit}
+          initialValues={{
+            title: ticket.title,
+            description: ticket.description,
+            priority: ticket.priority,
+            assignedTo: ticket.assignedToId,
+          }}
+          style={{ maxWidth: 600 }}
+        >
+          <Form.Item
+            name="title"
+            label="Title"
+            rules={[{ required: true, message: "Please enter a title" }]}
+          >
+            <Input placeholder="Ticket title" />
+          </Form.Item>
+
+          <Form.Item name="description" label="Description">
+            <TextArea
+              rows={4}
+              placeholder="Detailed description of the issue"
+            />
+          </Form.Item>
+
+          <Form.Item name="assignedTo" label="Assigned To">
+            <Select
+              showSearch
+              placeholder="Search employee..."
+              filterOption={false}
+              onSearch={handleEmployeeSearch}
+              options={employeeOptions}
+              loading={searching}
+              allowClear
+              notFoundContent={null}
+            />
+          </Form.Item>
+
+          <Form.Item
+            name="priority"
+            label="Priority"
+            rules={[{ required: true, message: "Please select a priority" }]}
+          >
+            <Select
+              options={[
+                { value: "LOW", label: "Low" },
+                { value: "MEDIUM", label: "Medium" },
+                { value: "HIGH", label: "High" },
+                { value: "URGENT", label: "Urgent" },
+              ]}
+            />
+          </Form.Item>
+
+          <Form.Item>
+            <Space>
+              <Button type="primary" htmlType="submit" loading={saving}>
+                Save Changes
+              </Button>
+              <Button onClick={() => navigate(`/support/tickets/${ticketId}`)}>
+                Cancel
+              </Button>
+            </Space>
+          </Form.Item>
+        </Form>
+      </Card>
+    </div>
+  );
+};
+
+export default EditTicket;

--- a/src/pages/support/EditTicket/index.ts
+++ b/src/pages/support/EditTicket/index.ts
@@ -1,0 +1,2 @@
+export { EditTicket } from "./EditTicket";
+export { default } from "./EditTicket";

--- a/src/pages/support/TicketDetails/TicketDetails.module.css
+++ b/src/pages/support/TicketDetails/TicketDetails.module.css
@@ -74,6 +74,18 @@
 
 .editableTag {
   cursor: pointer;
+  display: inline-flex !important;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid #d9d9d9 !important;
+  padding-right: 4px !important;
+}
+
+.editableTag::after {
+  content: "▾";
+  font-size: 10px;
+  line-height: 1;
+  opacity: 0.6;
 }
 
 .commentsSection {

--- a/src/pages/support/TicketDetails/TicketDetails.module.css
+++ b/src/pages/support/TicketDetails/TicketDetails.module.css
@@ -1,3 +1,138 @@
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.post {
+  background: #fff;
+  border: 1px solid #e8e8e8;
+  border-radius: 8px;
+  padding: 24px;
+}
+
+.postHeader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.avatar {
+  flex-shrink: 0;
+  background: #1677ff;
+}
+
+.headerMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.timestamp {
+  font-size: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.title {
+  margin-bottom: 12px !important;
+}
+
+.description {
+  padding: 12px 0;
+  border-bottom: 1px solid #f0f0f0;
+  margin-bottom: 16px;
+  white-space: pre-wrap;
+}
+
+.metadata {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  margin-bottom: 8px;
+}
+
+.metaItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.metaLabel {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.editableTag {
+  cursor: pointer;
+}
+
+.commentsSection {
+  margin-top: 8px;
+}
+
+.commentsHeading {
+  margin-bottom: 16px !important;
+}
+
+.commentsList {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.comment {
+  display: flex;
+  gap: 12px;
+}
+
+.commentAvatar {
+  flex-shrink: 0;
+  background: #87a9d4;
+}
+
+.commentBody {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+
+.commentMeta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.commentMessage {
+  white-space: pre-wrap;
+}
+
+.noComments {
+  display: block;
+  margin-bottom: 16px;
+}
+
+.addComment {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.commentButton {
+  align-self: flex-end;
+}
+
 .loading {
   display: flex;
   flex-direction: column;
@@ -5,17 +140,4 @@
   justify-content: center;
   min-height: 400px;
   gap: 16px;
-}
-
-.backButton {
-  margin-bottom: 16px;
-  display: block;
-}
-
-.commentsSection {
-  margin-top: 16px;
-}
-
-.addComment {
-  margin-top: 16px;
 }

--- a/src/pages/support/TicketDetails/TicketDetails.module.css
+++ b/src/pages/support/TicketDetails/TicketDetails.module.css
@@ -1,0 +1,21 @@
+.loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  gap: 16px;
+}
+
+.backButton {
+  margin-bottom: 16px;
+  display: block;
+}
+
+.commentsSection {
+  margin-top: 16px;
+}
+
+.addComment {
+  margin-top: 16px;
+}

--- a/src/pages/support/TicketDetails/TicketDetails.tsx
+++ b/src/pages/support/TicketDetails/TicketDetails.tsx
@@ -1,20 +1,23 @@
 import React, { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
-  Card,
-  Descriptions,
   Tag,
   Button,
   Select,
-  Space,
   Typography,
-  List,
   Input,
   message,
   Spin,
   Modal,
+  Avatar,
+  Divider,
 } from "antd";
-import { ArrowLeftOutlined } from "@ant-design/icons";
+import {
+  ArrowLeftOutlined,
+  DeleteOutlined,
+  UserOutlined,
+  ClockCircleOutlined,
+} from "@ant-design/icons";
 import { useTicket } from "../../../hooks/useSupport";
 import { supportService } from "../../../services/supportService";
 import type { TicketPriority, TicketStatus } from "../../../types/support";
@@ -36,6 +39,20 @@ const statusColors: Record<TicketStatus, string> = {
   RESOLVED: "success",
   CLOSED: "default",
 };
+
+function timeAgo(dateStr: string): string {
+  const now = Date.now();
+  const date = new Date(dateStr).getTime();
+  const diff = now - date;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(dateStr).toLocaleDateString();
+}
 
 export const TicketDetails: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -93,7 +110,7 @@ export const TicketDetails: React.FC = () => {
     if (!comment.trim()) return;
     setSubmitting(true);
     try {
-      await supportService.update(ticketId, { description: comment });
+      await supportService.addComment(ticketId, { message: comment });
       message.success("Comment added");
       setComment("");
       refetch();
@@ -124,42 +141,52 @@ export const TicketDetails: React.FC = () => {
   };
 
   return (
-    <div>
-      <Space className={styles.backButton}>
+    <div className={styles.container}>
+      <div className={styles.toolbar}>
         <Button
           icon={<ArrowLeftOutlined />}
           onClick={() => navigate("/support/tickets")}
         >
           Back to Tickets
         </Button>
-      </Space>
+        <Button danger icon={<DeleteOutlined />} onClick={handleDelete}>
+          Delete
+        </Button>
+      </div>
 
-      <Card
-        title={
-          <Title level={4} style={{ margin: 0 }}>
-            {ticket.title}
-          </Title>
-        }
-        extra={
-          <Space>
-            <Button danger onClick={handleDelete}>
-              Delete
-            </Button>
-          </Space>
-        }
-      >
-        <Descriptions column={2} bordered size="small">
-          <Descriptions.Item label="Customer">
-            {ticket.customerName || `#${ticket.customerId}`}
-          </Descriptions.Item>
-          <Descriptions.Item label="Description">
-            {ticket.description || "-"}
-          </Descriptions.Item>
-          <Descriptions.Item label="Status">
+      <div className={styles.post}>
+        <div className={styles.postHeader}>
+          <Avatar size={40} icon={<UserOutlined />} className={styles.avatar} />
+          <div className={styles.headerMeta}>
+            <Text strong>
+              {ticket.createdByName || ticket.customerName || "Unknown"}
+            </Text>
+            <Text type="secondary" className={styles.timestamp}>
+              <ClockCircleOutlined /> {timeAgo(ticket.createdAt)}
+            </Text>
+          </div>
+        </div>
+
+        <Title level={4} className={styles.title}>
+          #{ticket.id} - {ticket.title}
+        </Title>
+
+        {ticket.description && (
+          <div className={styles.description}>
+            <Text>{ticket.description}</Text>
+          </div>
+        )}
+
+        <div className={styles.metadata}>
+          <div className={styles.metaItem}>
+            <Text type="secondary" className={styles.metaLabel}>
+              Status
+            </Text>
             {editingStatus ? (
               <Select
                 defaultValue={ticket.status}
-                style={{ width: 140 }}
+                size="small"
+                style={{ width: 130 }}
                 onSelect={handleStatusChange}
                 onBlur={() => setEditingStatus(false)}
                 autoFocus
@@ -173,18 +200,22 @@ export const TicketDetails: React.FC = () => {
             ) : (
               <Tag
                 color={statusColors[ticket.status]}
-                style={{ cursor: "pointer" }}
+                className={styles.editableTag}
                 onClick={() => setEditingStatus(true)}
               >
                 {ticket.status.replace("_", " ")}
               </Tag>
             )}
-          </Descriptions.Item>
-          <Descriptions.Item label="Priority">
+          </div>
+          <div className={styles.metaItem}>
+            <Text type="secondary" className={styles.metaLabel}>
+              Priority
+            </Text>
             {editingPriority ? (
               <Select
                 defaultValue={ticket.priority}
-                style={{ width: 140 }}
+                size="small"
+                style={{ width: 120 }}
                 onSelect={handlePriorityChange}
                 onBlur={() => setEditingPriority(false)}
                 autoFocus
@@ -198,67 +229,92 @@ export const TicketDetails: React.FC = () => {
             ) : (
               <Tag
                 color={priorityColors[ticket.priority]}
-                style={{ cursor: "pointer" }}
+                className={styles.editableTag}
                 onClick={() => setEditingPriority(true)}
               >
                 {ticket.priority}
               </Tag>
             )}
-          </Descriptions.Item>
-          <Descriptions.Item label="Assigned To">
-            {ticket.assignedToName || "Unassigned"}
-          </Descriptions.Item>
-          <Descriptions.Item label="Created">
-            {new Date(ticket.createdAt).toLocaleString()}
-          </Descriptions.Item>
-          <Descriptions.Item label="Updated">
-            {new Date(ticket.updatedAt).toLocaleString()}
-          </Descriptions.Item>
-        </Descriptions>
-      </Card>
-
-      <Card title="Comments" className={styles.commentsSection}>
-        {ticket.comments.length > 0 ? (
-          <List
-            dataSource={ticket.comments}
-            renderItem={(item) => (
-              <List.Item>
-                <List.Item.Meta
-                  title={<Text strong>{item.authorName}</Text>}
-                  description={
-                    <Space direction="vertical" size={0}>
-                      <Text>{item.message}</Text>
-                      <Text type="secondary" style={{ fontSize: 12 }}>
-                        {new Date(item.createdAt).toLocaleString()}
-                      </Text>
-                    </Space>
-                  }
-                />
-              </List.Item>
-            )}
-          />
-        ) : (
-          <Text type="secondary">No comments yet.</Text>
-        )}
-
-        <div className={styles.addComment}>
-          <TextArea
-            rows={3}
-            value={comment}
-            onChange={(e) => setComment(e.target.value)}
-            placeholder="Add a comment..."
-          />
-          <Button
-            type="primary"
-            loading={submitting}
-            disabled={!comment.trim()}
-            onClick={handleAddComment}
-            style={{ marginTop: 8 }}
-          >
-            Add Comment
-          </Button>
+          </div>
+          <div className={styles.metaItem}>
+            <Text type="secondary" className={styles.metaLabel}>
+              Customer
+            </Text>
+            <Text>{ticket.customerName || `#${ticket.customerId}`}</Text>
+          </div>
+          <div className={styles.metaItem}>
+            <Text type="secondary" className={styles.metaLabel}>
+              Assigned To
+            </Text>
+            <Text>{ticket.assignedToName || "Unassigned"}</Text>
+          </div>
+          <div className={styles.metaItem}>
+            <Text type="secondary" className={styles.metaLabel}>
+              Created
+            </Text>
+            <Text>{new Date(ticket.createdAt).toLocaleDateString()}</Text>
+          </div>
+          <div className={styles.metaItem}>
+            <Text type="secondary" className={styles.metaLabel}>
+              Updated
+            </Text>
+            <Text>{new Date(ticket.updatedAt).toLocaleDateString()}</Text>
+          </div>
         </div>
-      </Card>
+
+        <Divider />
+
+        <div className={styles.commentsSection}>
+          <Title level={5} className={styles.commentsHeading}>
+            Comments ({ticket.comments.length})
+          </Title>
+
+          {ticket.comments.length > 0 ? (
+            <div className={styles.commentsList}>
+              {ticket.comments.map((c) => (
+                <div key={c.id} className={styles.comment}>
+                  <Avatar
+                    size={32}
+                    icon={<UserOutlined />}
+                    className={styles.commentAvatar}
+                  />
+                  <div className={styles.commentBody}>
+                    <div className={styles.commentMeta}>
+                      <Text strong>{c.authorName}</Text>
+                      <Text type="secondary" className={styles.timestamp}>
+                        <ClockCircleOutlined /> {timeAgo(c.createdAt)}
+                      </Text>
+                    </div>
+                    <Text className={styles.commentMessage}>{c.message}</Text>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <Text type="secondary" className={styles.noComments}>
+              No comments yet.
+            </Text>
+          )}
+
+          <div className={styles.addComment}>
+            <TextArea
+              rows={3}
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              placeholder="Add a comment..."
+            />
+            <Button
+              type="primary"
+              loading={submitting}
+              disabled={!comment.trim()}
+              onClick={handleAddComment}
+              className={styles.commentButton}
+            >
+              Comment
+            </Button>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/support/TicketDetails/TicketDetails.tsx
+++ b/src/pages/support/TicketDetails/TicketDetails.tsx
@@ -4,6 +4,7 @@ import {
   Tag,
   Button,
   Select,
+  Space,
   Typography,
   Input,
   message,
@@ -15,6 +16,7 @@ import {
 import {
   ArrowLeftOutlined,
   DeleteOutlined,
+  EditOutlined,
   UserOutlined,
   ClockCircleOutlined,
 } from "@ant-design/icons";
@@ -84,6 +86,10 @@ export const TicketDetails: React.FC = () => {
     );
   }
 
+  const isEditable =
+    ticket.status === "OPEN" || ticket.status === "IN_PROGRESS";
+  const isClosed = ticket.status === "CLOSED";
+
   const handleStatusChange = async (newStatus: TicketStatus) => {
     try {
       await supportService.update(ticketId, { status: newStatus });
@@ -149,9 +155,21 @@ export const TicketDetails: React.FC = () => {
         >
           Back to Tickets
         </Button>
-        <Button danger icon={<DeleteOutlined />} onClick={handleDelete}>
-          Delete
-        </Button>
+        <Space>
+          {isEditable && (
+            <Button
+              icon={<EditOutlined />}
+              onClick={() => navigate(`/support/tickets/${ticketId}/edit`)}
+            >
+              Edit
+            </Button>
+          )}
+          {isEditable && (
+            <Button danger icon={<DeleteOutlined />} onClick={handleDelete}>
+              Delete
+            </Button>
+          )}
+        </Space>
       </div>
 
       <div className={styles.post}>
@@ -198,13 +216,35 @@ export const TicketDetails: React.FC = () => {
                 ]}
               />
             ) : (
-              <Tag
-                color={statusColors[ticket.status]}
-                className={styles.editableTag}
-                onClick={() => setEditingStatus(true)}
-              >
-                {ticket.status.replace("_", " ")}
-              </Tag>
+              <Space>
+                <Tag
+                  color={statusColors[ticket.status]}
+                  className={isEditable ? styles.editableTag : undefined}
+                  onClick={() => isEditable && setEditingStatus(true)}
+                  style={isEditable ? { cursor: "pointer" } : undefined}
+                >
+                  {ticket.status.replace("_", " ")}
+                </Tag>
+                {ticket.status === "RESOLVED" && (
+                  <Button
+                    size="small"
+                    type="primary"
+                    onClick={async () => {
+                      try {
+                        await supportService.update(ticketId, {
+                          status: "OPEN",
+                        });
+                        message.success("Ticket reopened");
+                        refetch();
+                      } catch {
+                        message.error("Failed to reopen ticket");
+                      }
+                    }}
+                  >
+                    Reopen
+                  </Button>
+                )}
+              </Space>
             )}
           </div>
           <div className={styles.metaItem}>
@@ -229,8 +269,9 @@ export const TicketDetails: React.FC = () => {
             ) : (
               <Tag
                 color={priorityColors[ticket.priority]}
-                className={styles.editableTag}
-                onClick={() => setEditingPriority(true)}
+                className={isEditable ? styles.editableTag : undefined}
+                onClick={() => isEditable && setEditingPriority(true)}
+                style={isEditable ? { cursor: "pointer" } : undefined}
               >
                 {ticket.priority}
               </Tag>
@@ -296,23 +337,27 @@ export const TicketDetails: React.FC = () => {
             </Text>
           )}
 
-          <div className={styles.addComment}>
-            <TextArea
-              rows={3}
-              value={comment}
-              onChange={(e) => setComment(e.target.value)}
-              placeholder="Add a comment..."
-            />
-            <Button
-              type="primary"
-              loading={submitting}
-              disabled={!comment.trim()}
-              onClick={handleAddComment}
-              className={styles.commentButton}
-            >
-              Comment
-            </Button>
-          </div>
+          {isClosed ? (
+            <Text type="secondary">This ticket is closed.</Text>
+          ) : (
+            <div className={styles.addComment}>
+              <TextArea
+                rows={3}
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                placeholder="Add a comment..."
+              />
+              <Button
+                type="primary"
+                loading={submitting}
+                disabled={!comment.trim()}
+                onClick={handleAddComment}
+                className={styles.commentButton}
+              >
+                Comment
+              </Button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/support/TicketDetails/TicketDetails.tsx
+++ b/src/pages/support/TicketDetails/TicketDetails.tsx
@@ -219,9 +219,8 @@ export const TicketDetails: React.FC = () => {
               <Space>
                 <Tag
                   color={statusColors[ticket.status]}
-                  className={isEditable ? styles.editableTag : undefined}
+                  className={styles.editableTag}
                   onClick={() => isEditable && setEditingStatus(true)}
-                  style={isEditable ? { cursor: "pointer" } : undefined}
                 >
                   {ticket.status.replace("_", " ")}
                 </Tag>

--- a/src/pages/support/TicketDetails/TicketDetails.tsx
+++ b/src/pages/support/TicketDetails/TicketDetails.tsx
@@ -1,0 +1,266 @@
+import React, { useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  Card,
+  Descriptions,
+  Tag,
+  Button,
+  Select,
+  Space,
+  Typography,
+  List,
+  Input,
+  message,
+  Spin,
+  Modal,
+} from "antd";
+import { ArrowLeftOutlined } from "@ant-design/icons";
+import { useTicket } from "../../../hooks/useSupport";
+import { supportService } from "../../../services/supportService";
+import type { TicketPriority, TicketStatus } from "../../../types/support";
+import styles from "./TicketDetails.module.css";
+
+const { Title, Text } = Typography;
+const { TextArea } = Input;
+
+const priorityColors: Record<TicketPriority, string> = {
+  LOW: "green",
+  MEDIUM: "blue",
+  HIGH: "orange",
+  URGENT: "red",
+};
+
+const statusColors: Record<TicketStatus, string> = {
+  OPEN: "default",
+  IN_PROGRESS: "processing",
+  RESOLVED: "success",
+  CLOSED: "default",
+};
+
+export const TicketDetails: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const ticketId = Number(id);
+  const { data: ticket, loading, error, refetch } = useTicket(ticketId);
+  const [comment, setComment] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [editingStatus, setEditingStatus] = useState(false);
+  const [editingPriority, setEditingPriority] = useState(false);
+
+  if (loading) {
+    return (
+      <div className={styles.loading}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (error || !ticket) {
+    return (
+      <div className={styles.loading}>
+        <Text type="danger">{error || "Ticket not found"}</Text>
+        <br />
+        <Button onClick={() => navigate("/support/tickets")}>
+          Back to Tickets
+        </Button>
+      </div>
+    );
+  }
+
+  const handleStatusChange = async (newStatus: TicketStatus) => {
+    try {
+      await supportService.update(ticketId, { status: newStatus });
+      message.success("Status updated");
+      setEditingStatus(false);
+      refetch();
+    } catch {
+      message.error("Failed to update status");
+    }
+  };
+
+  const handlePriorityChange = async (newPriority: TicketPriority) => {
+    try {
+      await supportService.update(ticketId, { priority: newPriority });
+      message.success("Priority updated");
+      setEditingPriority(false);
+      refetch();
+    } catch {
+      message.error("Failed to update priority");
+    }
+  };
+
+  const handleAddComment = async () => {
+    if (!comment.trim()) return;
+    setSubmitting(true);
+    try {
+      await supportService.update(ticketId, { description: comment });
+      message.success("Comment added");
+      setComment("");
+      refetch();
+    } catch {
+      message.error("Failed to add comment");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = () => {
+    Modal.confirm({
+      title: "Delete Ticket",
+      content: "Are you sure you want to delete this ticket?",
+      okText: "Delete",
+      okType: "danger",
+      cancelText: "Cancel",
+      onOk: async () => {
+        try {
+          await supportService.delete(ticketId);
+          message.success("Ticket deleted");
+          navigate("/support/tickets");
+        } catch {
+          message.error("Failed to delete ticket");
+        }
+      },
+    });
+  };
+
+  return (
+    <div>
+      <Space className={styles.backButton}>
+        <Button
+          icon={<ArrowLeftOutlined />}
+          onClick={() => navigate("/support/tickets")}
+        >
+          Back to Tickets
+        </Button>
+      </Space>
+
+      <Card
+        title={
+          <Title level={4} style={{ margin: 0 }}>
+            {ticket.title}
+          </Title>
+        }
+        extra={
+          <Space>
+            <Button danger onClick={handleDelete}>
+              Delete
+            </Button>
+          </Space>
+        }
+      >
+        <Descriptions column={2} bordered size="small">
+          <Descriptions.Item label="Customer">
+            {ticket.customerName || `#${ticket.customerId}`}
+          </Descriptions.Item>
+          <Descriptions.Item label="Description">
+            {ticket.description || "-"}
+          </Descriptions.Item>
+          <Descriptions.Item label="Status">
+            {editingStatus ? (
+              <Select
+                defaultValue={ticket.status}
+                style={{ width: 140 }}
+                onSelect={handleStatusChange}
+                onBlur={() => setEditingStatus(false)}
+                autoFocus
+                options={[
+                  { value: "OPEN", label: "Open" },
+                  { value: "IN_PROGRESS", label: "In Progress" },
+                  { value: "RESOLVED", label: "Resolved" },
+                  { value: "CLOSED", label: "Closed" },
+                ]}
+              />
+            ) : (
+              <Tag
+                color={statusColors[ticket.status]}
+                style={{ cursor: "pointer" }}
+                onClick={() => setEditingStatus(true)}
+              >
+                {ticket.status.replace("_", " ")}
+              </Tag>
+            )}
+          </Descriptions.Item>
+          <Descriptions.Item label="Priority">
+            {editingPriority ? (
+              <Select
+                defaultValue={ticket.priority}
+                style={{ width: 140 }}
+                onSelect={handlePriorityChange}
+                onBlur={() => setEditingPriority(false)}
+                autoFocus
+                options={[
+                  { value: "LOW", label: "Low" },
+                  { value: "MEDIUM", label: "Medium" },
+                  { value: "HIGH", label: "High" },
+                  { value: "URGENT", label: "Urgent" },
+                ]}
+              />
+            ) : (
+              <Tag
+                color={priorityColors[ticket.priority]}
+                style={{ cursor: "pointer" }}
+                onClick={() => setEditingPriority(true)}
+              >
+                {ticket.priority}
+              </Tag>
+            )}
+          </Descriptions.Item>
+          <Descriptions.Item label="Assigned To">
+            {ticket.assignedToName || "Unassigned"}
+          </Descriptions.Item>
+          <Descriptions.Item label="Created">
+            {new Date(ticket.createdAt).toLocaleString()}
+          </Descriptions.Item>
+          <Descriptions.Item label="Updated">
+            {new Date(ticket.updatedAt).toLocaleString()}
+          </Descriptions.Item>
+        </Descriptions>
+      </Card>
+
+      <Card title="Comments" className={styles.commentsSection}>
+        {ticket.comments.length > 0 ? (
+          <List
+            dataSource={ticket.comments}
+            renderItem={(item) => (
+              <List.Item>
+                <List.Item.Meta
+                  title={<Text strong>{item.authorName}</Text>}
+                  description={
+                    <Space direction="vertical" size={0}>
+                      <Text>{item.message}</Text>
+                      <Text type="secondary" style={{ fontSize: 12 }}>
+                        {new Date(item.createdAt).toLocaleString()}
+                      </Text>
+                    </Space>
+                  }
+                />
+              </List.Item>
+            )}
+          />
+        ) : (
+          <Text type="secondary">No comments yet.</Text>
+        )}
+
+        <div className={styles.addComment}>
+          <TextArea
+            rows={3}
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="Add a comment..."
+          />
+          <Button
+            type="primary"
+            loading={submitting}
+            disabled={!comment.trim()}
+            onClick={handleAddComment}
+            style={{ marginTop: 8 }}
+          >
+            Add Comment
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default TicketDetails;

--- a/src/pages/support/TicketDetails/index.ts
+++ b/src/pages/support/TicketDetails/index.ts
@@ -1,0 +1,2 @@
+export { TicketDetails } from "./TicketDetails";
+export { default } from "./TicketDetails";

--- a/src/pages/support/TicketsList/TicketsList.module.css
+++ b/src/pages/support/TicketsList/TicketsList.module.css
@@ -1,0 +1,10 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.filters {
+  margin-bottom: 16px;
+}

--- a/src/pages/support/TicketsList/TicketsList.module.css
+++ b/src/pages/support/TicketsList/TicketsList.module.css
@@ -5,6 +5,12 @@
   margin-bottom: 16px;
 }
 
+.viewToggle {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
 .filters {
   margin-bottom: 16px;
 }

--- a/src/pages/support/TicketsList/TicketsList.tsx
+++ b/src/pages/support/TicketsList/TicketsList.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { Table, Tag, Button, Input, Select, Space, Typography } from "antd";
 import { PlusOutlined } from "@ant-design/icons";
+import { AuthContext } from "../../../contexts/AuthContext";
 import { useTickets } from "../../../hooks/useSupport";
 import type {
   Ticket,
@@ -28,6 +29,12 @@ const statusColors: Record<TicketStatus, string> = {
 
 export const TicketsList: React.FC = () => {
   const navigate = useNavigate();
+  const { user } = useContext(AuthContext) || {};
+  const userId = user?.id;
+  const isAdmin = user?.role === "ADMIN" || user?.role === "MANAGER";
+  const [view, setView] = useState<"my" | "assigned" | "all">(
+    isAdmin ? "all" : "my",
+  );
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<TicketStatus | "">("");
   const [priorityFilter, setPriorityFilter] = useState<TicketPriority | "">("");
@@ -39,16 +46,22 @@ export const TicketsList: React.FC = () => {
     search?: string;
     status?: TicketStatus;
     priority?: TicketPriority;
+    createdById?: number;
+    assignedToId?: number;
   } = {
     page,
     size: 20,
   };
+  if (view === "my" && userId) filters.createdById = userId;
+  if (view === "assigned" && userId) filters.assignedToId = userId;
   if (search) filters.search = search;
   if (statusFilter) filters.status = statusFilter as TicketStatus;
   if (priorityFilter) filters.priority = priorityFilter as TicketPriority;
 
+  const hasActiveFilters =
+    search || statusFilter || priorityFilter || view !== "all";
   const { data, total, loading } = useTickets(
-    search || statusFilter || priorityFilter ? filters : { page, size: 20 },
+    hasActiveFilters ? filters : { page, size: 20 },
   );
 
   const columns = [
@@ -109,6 +122,41 @@ export const TicketsList: React.FC = () => {
         >
           New Ticket
         </Button>
+      </div>
+
+      <div className={styles.viewToggle}>
+        <Button
+          type={view === "my" ? "primary" : "default"}
+          size="small"
+          onClick={() => {
+            setView("my");
+            setPage(0);
+          }}
+        >
+          My Tickets
+        </Button>
+        <Button
+          type={view === "assigned" ? "primary" : "default"}
+          size="small"
+          onClick={() => {
+            setView("assigned");
+            setPage(0);
+          }}
+        >
+          Assigned
+        </Button>
+        {isAdmin && (
+          <Button
+            type={view === "all" ? "primary" : "default"}
+            size="small"
+            onClick={() => {
+              setView("all");
+              setPage(0);
+            }}
+          >
+            All
+          </Button>
+        )}
       </div>
 
       <Space className={styles.filters}>

--- a/src/pages/support/TicketsList/TicketsList.tsx
+++ b/src/pages/support/TicketsList/TicketsList.tsx
@@ -1,0 +1,176 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Table, Tag, Button, Input, Select, Space, Typography } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+import { useTickets } from "../../../hooks/useSupport";
+import type {
+  Ticket,
+  TicketPriority,
+  TicketStatus,
+} from "../../../types/support";
+import styles from "./TicketsList.module.css";
+
+const { Title } = Typography;
+
+const priorityColors: Record<TicketPriority, string> = {
+  LOW: "green",
+  MEDIUM: "blue",
+  HIGH: "orange",
+  URGENT: "red",
+};
+
+const statusColors: Record<TicketStatus, string> = {
+  OPEN: "default",
+  IN_PROGRESS: "processing",
+  RESOLVED: "success",
+  CLOSED: "default",
+};
+
+export const TicketsList: React.FC = () => {
+  const navigate = useNavigate();
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<TicketStatus | "">("");
+  const [priorityFilter, setPriorityFilter] = useState<TicketPriority | "">("");
+  const [page, setPage] = useState(0);
+
+  const filters: {
+    page: number;
+    size: number;
+    search?: string;
+    status?: TicketStatus;
+    priority?: TicketPriority;
+  } = {
+    page,
+    size: 20,
+  };
+  if (search) filters.search = search;
+  if (statusFilter) filters.status = statusFilter as TicketStatus;
+  if (priorityFilter) filters.priority = priorityFilter as TicketPriority;
+
+  const { data, total, loading } = useTickets(
+    search || statusFilter || priorityFilter ? filters : { page, size: 20 },
+  );
+
+  const columns = [
+    {
+      title: "ID",
+      dataIndex: "id",
+      key: "id",
+      width: 60,
+    },
+    {
+      title: "Title",
+      dataIndex: "title",
+      key: "title",
+    },
+    {
+      title: "Customer",
+      dataIndex: "customerName",
+      key: "customerName",
+    },
+    {
+      title: "Priority",
+      dataIndex: "priority",
+      key: "priority",
+      render: (priority: TicketPriority) => (
+        <Tag color={priorityColors[priority]}>{priority}</Tag>
+      ),
+    },
+    {
+      title: "Status",
+      dataIndex: "status",
+      key: "status",
+      render: (status: TicketStatus) => (
+        <Tag color={statusColors[status]}>{status.replace("_", " ")}</Tag>
+      ),
+    },
+    {
+      title: "Assigned To",
+      dataIndex: "assignedToName",
+      key: "assignedToName",
+      render: (name: string | undefined) => name || "-",
+    },
+    {
+      title: "Created",
+      dataIndex: "createdAt",
+      key: "createdAt",
+      render: (date: string) => new Date(date).toLocaleDateString(),
+    },
+  ];
+
+  return (
+    <div>
+      <div className={styles.header}>
+        <Title level={3}>Support Tickets</Title>
+        <Button
+          type="primary"
+          icon={<PlusOutlined />}
+          onClick={() => navigate("/support/tickets/new")}
+        >
+          New Ticket
+        </Button>
+      </div>
+
+      <Space className={styles.filters}>
+        <Input.Search
+          placeholder="Search tickets..."
+          allowClear
+          onSearch={(value) => {
+            setSearch(value);
+            setPage(0);
+          }}
+          style={{ width: 250 }}
+        />
+        <Select
+          placeholder="Status"
+          allowClear
+          style={{ width: 140 }}
+          onChange={(value) => {
+            setStatusFilter(value || "");
+            setPage(0);
+          }}
+          options={[
+            { value: "OPEN", label: "Open" },
+            { value: "IN_PROGRESS", label: "In Progress" },
+            { value: "RESOLVED", label: "Resolved" },
+            { value: "CLOSED", label: "Closed" },
+          ]}
+        />
+        <Select
+          placeholder="Priority"
+          allowClear
+          style={{ width: 140 }}
+          onChange={(value) => {
+            setPriorityFilter(value || "");
+            setPage(0);
+          }}
+          options={[
+            { value: "LOW", label: "Low" },
+            { value: "MEDIUM", label: "Medium" },
+            { value: "HIGH", label: "High" },
+            { value: "URGENT", label: "Urgent" },
+          ]}
+        />
+      </Space>
+
+      <Table<Ticket>
+        columns={columns}
+        dataSource={data}
+        rowKey="id"
+        loading={loading}
+        pagination={{
+          current: page + 1,
+          total,
+          pageSize: 20,
+          onChange: (p) => setPage(p - 1),
+        }}
+        onRow={(record) => ({
+          onClick: () => navigate(`/support/tickets/${record.id}`),
+          style: { cursor: "pointer" },
+        })}
+      />
+    </div>
+  );
+};
+
+export default TicketsList;

--- a/src/pages/support/TicketsList/index.ts
+++ b/src/pages/support/TicketsList/index.ts
@@ -1,0 +1,2 @@
+export { TicketsList } from "./TicketsList";
+export { default } from "./TicketsList";

--- a/src/pages/support/index.ts
+++ b/src/pages/support/index.ts
@@ -1,0 +1,3 @@
+export { TicketsList } from "./TicketsList";
+export { TicketDetails } from "./TicketDetails";
+export { CreateTicket } from "./CreateTicket";

--- a/src/pages/support/index.ts
+++ b/src/pages/support/index.ts
@@ -1,3 +1,4 @@
 export { TicketsList } from "./TicketsList";
 export { TicketDetails } from "./TicketDetails";
 export { CreateTicket } from "./CreateTicket";
+export { EditTicket } from "./EditTicket";

--- a/src/services/supportService.ts
+++ b/src/services/supportService.ts
@@ -19,6 +19,9 @@ export const supportService = {
     if (filters.status) params.status = filters.status;
     if (filters.priority) params.priority = filters.priority;
     if (filters.search) params.search = filters.search;
+    if (filters.createdById) params.createdById = String(filters.createdById);
+    if (filters.assignedToId)
+      params.assignedToId = String(filters.assignedToId);
 
     const response = await apiClient.get(endpoints.support.list, { params });
     return {

--- a/src/services/supportService.ts
+++ b/src/services/supportService.ts
@@ -1,0 +1,48 @@
+import { apiClient } from "../api/client";
+import { endpoints } from "../api/endpoints";
+import type {
+  Ticket,
+  CreateTicketDto,
+  UpdateTicketDto,
+  TicketFilters,
+} from "../types/support";
+
+export const supportService = {
+  async getAll(
+    filters: TicketFilters = {},
+  ): Promise<{ data: Ticket[]; total: number }> {
+    const params: Record<string, string> = {};
+    params.page = String(filters.page ?? 0);
+    params.size = String(filters.size ?? 20);
+    if (filters.status) params.status = filters.status;
+    if (filters.priority) params.priority = filters.priority;
+    if (filters.search) params.search = filters.search;
+
+    const response = await apiClient.get(endpoints.support.list, { params });
+    return {
+      data: response.data.data.content || [],
+      total: response.data.data.totalElements || 0,
+    };
+  },
+
+  async getById(id: number): Promise<Ticket> {
+    const response = await apiClient.get(endpoints.support.getById(id));
+    return response.data.data;
+  },
+
+  async create(data: CreateTicketDto): Promise<Ticket> {
+    const response = await apiClient.post(endpoints.support.create, data);
+    return response.data.data;
+  },
+
+  async update(id: number, data: UpdateTicketDto): Promise<Ticket> {
+    const response = await apiClient.put(endpoints.support.update(id), data);
+    return response.data.data;
+  },
+
+  async delete(id: number): Promise<void> {
+    await apiClient.delete(endpoints.support.delete(id));
+  },
+};
+
+export default supportService;

--- a/src/services/supportService.ts
+++ b/src/services/supportService.ts
@@ -5,6 +5,8 @@ import type {
   CreateTicketDto,
   UpdateTicketDto,
   TicketFilters,
+  AddCommentDto,
+  TicketComment,
 } from "../types/support";
 
 export const supportService = {
@@ -42,6 +44,17 @@ export const supportService = {
 
   async delete(id: number): Promise<void> {
     await apiClient.delete(endpoints.support.delete(id));
+  },
+
+  async addComment(
+    ticketId: number,
+    data: AddCommentDto,
+  ): Promise<TicketComment> {
+    const response = await apiClient.post(
+      endpoints.support.addComment(ticketId),
+      data,
+    );
+    return response.data.data;
   },
 };
 

--- a/src/types/support.ts
+++ b/src/types/support.ts
@@ -55,4 +55,6 @@ export interface TicketFilters {
   status?: TicketStatus;
   priority?: TicketPriority;
   search?: string;
+  createdById?: number;
+  assignedToId?: number;
 }

--- a/src/types/support.ts
+++ b/src/types/support.ts
@@ -34,6 +34,7 @@ export interface CreateTicketDto {
   description?: string;
   customerId: number;
   priority: TicketPriority;
+  assignedTo?: number;
 }
 
 export interface AddCommentDto {

--- a/src/types/support.ts
+++ b/src/types/support.ts
@@ -1,0 +1,55 @@
+export type TicketPriority = "LOW" | "MEDIUM" | "HIGH" | "URGENT";
+
+export type TicketStatus = "OPEN" | "IN_PROGRESS" | "RESOLVED" | "CLOSED";
+
+export interface Ticket {
+  id: number;
+  title: string;
+  description?: string;
+  customerId: number;
+  customerName?: string;
+  priority: TicketPriority;
+  status: TicketStatus;
+  assignedToId?: number;
+  assignedToName?: string;
+  createdAt: string;
+  updatedAt: string;
+  comments: TicketComment[];
+}
+
+export interface TicketComment {
+  id: number;
+  ticketId: number;
+  authorId: number;
+  authorName: string;
+  message: string;
+  isInternal: boolean;
+  createdAt: string;
+}
+
+export interface CreateTicketDto {
+  title: string;
+  description?: string;
+  customerId: number;
+  priority: TicketPriority;
+}
+
+export interface AddCommentDto {
+  message: string;
+}
+
+export interface UpdateTicketDto {
+  title?: string;
+  description?: string;
+  priority?: TicketPriority;
+  status?: TicketStatus;
+  assignedTo?: number;
+}
+
+export interface TicketFilters {
+  page?: number;
+  size?: number;
+  status?: TicketStatus;
+  priority?: TicketPriority;
+  search?: string;
+}

--- a/src/types/support.ts
+++ b/src/types/support.ts
@@ -12,6 +12,8 @@ export interface Ticket {
   status: TicketStatus;
   assignedToId?: number;
   assignedToName?: string;
+  createdById?: number;
+  createdByName?: string;
   createdAt: string;
   updatedAt: string;
   comments: TicketComment[];


### PR DESCRIPTION
## Summary

Implements the complete Helpdesk/Support frontend module covering the full ticket lifecycle — create, view, comment, edit, and filter tickets with role-based access control.

### Pages

| Page | Route | Description |
|------|-------|-------------|
| **TicketsList** | `/support/tickets` | Paginated list with view toggle (My Tickets / Assigned / All) based on user role |
| **CreateTicket** | `/support/tickets/new` | Form with customer searchable Select, employee assignment, priority, channel |
| **TicketDetails** | `/support/tickets/:id` | Reddit-style layout with author avatar, threaded comments, inline editable status/priority |
| **EditTicket** | `/support/tickets/:id/edit` | Full edit form with employee search — status-gated (OPEN/IN_PROGRESS editable, RESOLVED→Reopen, CLOSED read-only) |

### Features
- **Sidebar** — Support menu item added to main navigation
- **API layer** — Full CRUD service (`supportService.ts`) + comment endpoint wiring
- **Hooks** — `useTickets`, `useTicket`, `useCreateTicket`, `useUpdateTicket` with barrel exports
- **Status gating** — Editing disabled based on ticket status with clear UX cues
- **View toggle** — Role-aware filter: employees see My/Assigned/All, admins see All
- **Styling** — Inline editable tags with border + dropdown arrow, Reddit-style comment threading

### Technical Stack
- React 18 + TypeScript + Vite
- CSS Modules for component styling
- Custom hooks for data fetching (axios-based)
- Spring Boot backend API integration

### Files Changed
21 files, +2,212 insertions, -1 deletion